### PR TITLE
UpgradedVehiclesForceUnlocks

### DIFF
--- a/CustomCraftSML/SampleFiles/AddedRecipes_Samples2.txt
+++ b/CustomCraftSML/SampleFiles/AddedRecipes_Samples2.txt
@@ -1,29 +1,29 @@
-AddedRecipes:
+AddedRecipes: 
 (
-    ItemID:NutrientBlock;
-    AmountCrafted:1;
-    Ingredients:
+    ItemID: NutrientBlock;
+    AmountCrafted: 1;
+    Ingredients: 
     (
-        ItemID:CuredReginald;
-        Required:1;
+        ItemID: CuredReginald;
+        Required: 1;
     ),
     (
-        ItemID:PurpleVegetable;
-        Required:1;
+        ItemID: PurpleVegetable;
+        Required: 1;
     ),
     (
-        ItemID:HangingFruit;
-        Required:1;
+        ItemID: HangingFruit;
+        Required: 1;
     );
-    Path:Fabricator/Survival/CuredFood;
+    Path: Fabricator/Survival/CuredFood;
 ),
 (
-    ItemID:BigFilteredWater;
-    AmountCrafted:1;
-    Ingredients:
+    ItemID: BigFilteredWater;
+    AmountCrafted: 1;
+    Ingredients: 
     (
-        ItemID:FilteredWater;
-        Required:2;
+        ItemID: FilteredWater;
+        Required: 2;
     );
-    Path:Fabricator/Survival/Water;
+    Path: Fabricator/Survival/Water;
 );

--- a/CustomCraftSML/SampleFiles/CustomSizes_Samples2.txt
+++ b/CustomCraftSML/SampleFiles/CustomSizes_Samples2.txt
@@ -1,16 +1,16 @@
-CustomSizes:
+CustomSizes: 
 (
-    ItemID:BloodOil;
-    Width:1;
-    Height:1;
+    ItemID: BloodOil;
+    Width: 1;
+    Height: 1;
 ),
 (
-    ItemID:BulboTreePiece;
-    Width:1;
-    Height:1;
+    ItemID: BulboTreePiece;
+    Width: 1;
+    Height: 1;
 ),
 (
-    ItemID:PurpleVegetable;
-    Width:1;
-    Height:1;
+    ItemID: PurpleVegetable;
+    Width: 1;
+    Height: 1;
 );

--- a/CustomCraftSML/SampleFiles/ModifiedRecipes_Samples2.txt
+++ b/CustomCraftSML/SampleFiles/ModifiedRecipes_Samples2.txt
@@ -1,15 +1,15 @@
-ModifiedRecipes:
+ModifiedRecipes: 
 (
-    ItemID:CuredReginald;
-    AmountCrafted:1;
-    Ingredients:
+    ItemID: CuredReginald;
+    AmountCrafted: 1;
+    Ingredients: 
     (
-        ItemID:Reginald;
-        Required:1;
+        ItemID: Reginald;
+        Required: 1;
     ),
     (
-        ItemID:Salt;
-        Required:1;
+        ItemID: Salt;
+        Required: 1;
     );
-    Unlocks:NutrientBlock;
+    Unlocks: NutrientBlock;
 );

--- a/CustomCraftSMLTests/EasyMarkupTests.cs
+++ b/CustomCraftSMLTests/EasyMarkupTests.cs
@@ -76,7 +76,7 @@
             Assert.Throws<AssertionException>(() =>
             {
                 testProp.FromString(serialValue, true);
-            });            
+            });
         }
 
         [TestCase("TestAKey:1;", 1)]
@@ -388,27 +388,27 @@
         [Test]
         public void EmPropertyCollection_WithNestedCollection_PrettyPrint_GetExpected()
         {
-            const string testValue = "TestKey:" +
+            const string testValue = "TestKey: " +
                                      "(" +
-                                         "String:Val;" +
-                                         "Int:12;" +
-                                         "FloatList:1,2.1,3.2;" +
+                                         "String: Val;" +
+                                         "Int: 12;" +
+                                         "FloatList: 1,2.1,3.2;" +
                                          "Nested:" +
                                          "(" +
-                                             "Nstring:Nval;" +
-                                             "Nint:10;" +
+                                             "Nstring: Nval;" +
+                                             "Nint: 10;" +
                                          ");" +
                                      ");";
 
-            const string expectedValue = "TestKey:\r\n" +
+            const string expectedValue = "TestKey: \r\n" +
                                          "(\r\n" +
-                                         "    String:Val;\r\n" +
-                                         "    Int:12;\r\n" +
-                                         "    FloatList:1,2.1,3.2;\r\n" +
-                                         "    Nested:\r\n" +
+                                         "    String: Val;\r\n" +
+                                         "    Int: 12;\r\n" +
+                                         "    FloatList: 1,2.1,3.2;\r\n" +
+                                         "    Nested: \r\n" +
                                          "    (\r\n" +
-                                         "        Nstring:Nval;\r\n" +
-                                         "        Nint:10;\r\n" +
+                                         "        Nstring: Nval;\r\n" +
+                                         "        Nint: 10;\r\n" +
                                          "    );\r\n" +
                                          ");\r\n";
 
@@ -432,6 +432,16 @@
             var actualValue = testProp.PrettyPrint();
 
             Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [Test]
+        public void EmProperty_SuperSImple_PrettyPrint_GetExpected()
+        {
+            var emString = new EmProperty<string>("String", "Value");
+
+            var actualValue = emString.PrettyPrint();
+
+            Assert.AreEqual("String: Value;\r\n", actualValue);
         }
     }
 }

--- a/UpgradedVehicles/Craftables/ExosuitMk2.cs
+++ b/UpgradedVehicles/Craftables/ExosuitMk2.cs
@@ -5,26 +5,21 @@
 
     internal class ExosuitMk2 : UpgradedVehicle<Exosuit>
     {
-        public static TechType TechTypeID { get; private set; }
-
-        internal readonly TechType PowerCoreID;
-
-        internal ExosuitMk2(VehiclePowerCore vehiclePowerCore) 
-            : base("ExosuitMk2",
-                  "Prawn Suit MK2",
-                  "An upgraded Prawn Suit now even tougher to take on anything.",
-                  TechType.Exosuit,
-                  1.5f,
-                  TechType.ExoHullModule2)
+        internal ExosuitMk2(VehiclePowerCore vehiclePowerCore)
+            : base(
+                  nameID: "ExosuitMk2",
+                  friendlyName: "Prawn Suit MK2",
+                  description: "An upgraded Prawn Suit now even tougher to take on anything.",
+                  template: TechType.Exosuit,
+                  healthModifier: 1.5f,
+                  requiredAnalysis: TechType.ExoHullModule2,
+                  powerCore: vehiclePowerCore)
         {
-            PowerCoreID = vehiclePowerCore.TechType;
         }
 
-        public override void Patch()
+        protected override void PostPatch()
         {
-            base.Patch();
-
-            TechTypeID = this.TechType;
+            MTechType.ExosuitMk2 = this.TechType;
         }
 
         protected override TechData GetRecipe()
@@ -40,7 +35,7 @@
                                  new Ingredient(TechType.Diamond, 2),
 
                                  new Ingredient(TechType.ExoHullModule2, 1), // Minimum crush depth of 1700 without upgrades
-                                 new Ingredient(PowerCoreID, 1),  // +2 to armor + speed without engine efficiency penalty
+                                 new Ingredient(PowerCore.TechType, 1),  // +2 to armor + speed without engine efficiency penalty
                              })
             };
         }

--- a/UpgradedVehicles/Craftables/SeaMothMk2.cs
+++ b/UpgradedVehicles/Craftables/SeaMothMk2.cs
@@ -5,26 +5,20 @@
 
     internal class SeaMothMk2 : UpgradedVehicle<SeaMoth>
     {
-        public static TechType TechTypeID { get; private set; }
-
-        internal readonly TechType PowerCoreID;
-
         internal SeaMothMk2(VehiclePowerCore vehiclePowerCore)
             : base(nameID: "SeaMothMk2",
                       friendlyName: "Seamoth MK2",
                       description: "An upgraded SeaMoth, built harder and faster to take you anywhere.",
                       template: TechType.Seamoth,
                       healthModifier: 2f, // 2x the Max HP. 100% more.
-                      requiredAnalysis: TechType.VehicleHullModule3)
+                      requiredAnalysis: TechType.VehicleHullModule3,
+                      powerCore: vehiclePowerCore)
         {
-            PowerCoreID = vehiclePowerCore.TechType;
         }
 
-        public override void Patch()
+        protected override void PostPatch()
         {
-            base.Patch();
-
-            TechTypeID = this.TechType;
+            MTechType.SeaMothMk2 = this.TechType;
         }
 
         protected override TechData GetRecipe()
@@ -34,12 +28,12 @@
                 craftAmount = 1,
                 Ingredients = new List<Ingredient>(new Ingredient[5]
                              {
-                                 new Ingredient(TechType.PlasteelIngot, 1), // Stronger than titanium ingot                                 
+                                 new Ingredient(TechType.PlasteelIngot, 1), // Stronger than titanium ingot
                                  new Ingredient(TechType.EnameledGlass, 2), // Stronger than glass
                                  new Ingredient(TechType.Lead, 1),
 
                                  new Ingredient(TechType.VehicleHullModule3, 1), // Minimum crush depth of 900 without upgrades
-                                 new Ingredient(PowerCoreID, 1), // armor and speed without engine efficiency penalty
+                                 new Ingredient(PowerCore.TechType, 1), // armor and speed without engine efficiency penalty
                              })
             };
         }

--- a/UpgradedVehicles/Craftables/SeaMothMk3.cs
+++ b/UpgradedVehicles/Craftables/SeaMothMk3.cs
@@ -6,42 +6,38 @@
 
     internal class SeaMothMk3 : UpgradedVehicle<SeaMoth>
     {
-        public static TechType TechTypeID { get; private set; } = TechType.Unobtanium; // Default for when not set but still used in comparisons
-        public static TechType SeamothHullModule4 { get; private set; } = TechType.Unobtanium;
-        public static TechType SeamothHullModule5 { get; private set; } = TechType.Unobtanium;
-
-        internal readonly TechType PowerCoreID;
-
         internal SeaMothMk3(VehiclePowerCore vehiclePowerCore)
-            : base(nameID: "SeaMothMk3",
-                      friendlyName: "Seamoth MK3",
-                      description: "The highest end SeaMoth. Ready for adventures in the most hostile of environments.",
-                      template: TechType.Seamoth,
-                      healthModifier: 2.15f, // 2.15x Max HP. 115% more.
-                      requiredAnalysis: TechType.VehicleHullModule3)
+            : base(
+                  nameID: "SeaMothMk3",
+                  friendlyName: "Seamoth MK3",
+                  description: "The highest end SeaMoth. Ready for adventures in the most hostile of environments.",
+                  template: TechType.Seamoth,
+                  healthModifier: 2.15f, // 2.15x Max HP. 115% more.
+                  requiredAnalysis: TechType.VehicleHullModule3,
+                  powerCore: vehiclePowerCore)
         {
-            PowerCoreID = vehiclePowerCore.TechType;
         }
 
-
-
-        public override void Patch()
+        protected override void PrePatch()
         {
             if (TechTypeHandler.TryGetModdedTechType("SeamothHullModule4", out TechType seamothDepthMk4) &&
                 TechTypeHandler.TryGetModdedTechType("SeamothHullModule5", out TechType seamothDepthMk5))
             {
-                SeamothHullModule4 = seamothDepthMk4;
-                SeamothHullModule5 = seamothDepthMk5;
+                MTechType.SeamothHullModule4 = seamothDepthMk4;
+                MTechType.SeamothHullModule5 = seamothDepthMk5;
 
                 // MoreSeamothUpgrades found. Patch normally.
-                base.Patch();
-                TechTypeID = this.TechType;
             }
             else
             {
                 // MoreSeamothUpgrades not found. Register just the TechType to preserve the ID.
-                this.TechType = TechTypeHandler.AddTechType(NameID, FriendlyName, Description);
+                PatchTechTypeOnly = true;
             }
+        }
+
+        protected override void PostPatch()
+        {
+            MTechType.SeaMothMk3 = this.TechType;
         }
 
         protected override TechData GetRecipe()
@@ -51,12 +47,12 @@
                 craftAmount = 1,
                 Ingredients = new List<Ingredient>(new Ingredient[5]
                              {
-                                 new Ingredient(TechType.PlasteelIngot, 1), // Stronger than titanium ingot                                 
+                                 new Ingredient(TechType.PlasteelIngot, 1), // Stronger than titanium ingot
                                  new Ingredient(TechType.EnameledGlass, 2), // Stronger than glass
                                  new Ingredient(TechType.Lead, 1),
 
-                                 new Ingredient(SeamothHullModule5, 1), // Minimum crush depth of 1700 without upgrades
-                                 new Ingredient(PowerCoreID, 1), // armor and speed without engine efficiency penalty
+                                 new Ingredient(MTechType.SeamothHullModule5, 1), // Minimum crush depth of 1700 without upgrades
+                                 new Ingredient(PowerCore.TechType, 1), // armor and speed without engine efficiency penalty
                              })
             };
         }

--- a/UpgradedVehicles/Craftables/SpeedBooster.cs
+++ b/UpgradedVehicles/Craftables/SpeedBooster.cs
@@ -6,9 +6,7 @@
 
     internal class SpeedBooster : Craftable
     {
-        public static TechType TechTypeID { get; private set; }
-        
-        internal SpeedBooster() 
+        internal SpeedBooster()
             : base(nameID: "SpeedModule",
                   friendlyName: "Speed Boost Module",
                   description: "Allows small vehicle engines to go into overdrive, adding greater speeds but at the cost of higher energy consumption rates.",
@@ -21,11 +19,12 @@
         {
         }
 
-        public override void Patch()
+        protected override void PrePatch() { }
+
+        protected override void PostPatch()
         {
-            base.Patch();
             CraftDataHandler.SetEquipmentType(this.TechType, EquipmentType.VehicleModule);
-            TechTypeID = this.TechType;
+            MTechType.SpeedBooster = this.TechType;
         }
 
         protected override TechData GetRecipe()

--- a/UpgradedVehicles/Craftables/UpgradedVehicle.cs
+++ b/UpgradedVehicles/Craftables/UpgradedVehicle.cs
@@ -28,16 +28,11 @@
                   fabricatorTab: "Vehicles",
                   requiredAnalysis: requiredAnalysis,
                   groupForPDA: TechGroup.Constructor,
-                  categoryForPDA: TechCategory.Constructor)
+                  categoryForPDA: TechCategory.Constructor,
+                  prerequisite: powerCore)
         {
             HealthModifier = healthModifier;
             PowerCore = powerCore;
-        }
-
-        protected override void PrePatch()
-        {
-            if (!PowerCore.IsPatched)
-                PowerCore.Patch();
         }
 
         public override GameObject GetGameObject()

--- a/UpgradedVehicles/Craftables/UpgradedVehicle.cs
+++ b/UpgradedVehicles/Craftables/UpgradedVehicle.cs
@@ -1,7 +1,7 @@
 ﻿namespace UpgradedVehicles
 {
     using System;
-    using Common;    
+    using Common;
     using UnityEngine;
 
     internal abstract class UpgradedVehicle<T> : Craftable where T : Vehicle
@@ -9,16 +9,35 @@
         private readonly Type VehicleComponentType = typeof(T);
         protected readonly float HealthModifier;
 
+        protected readonly VehiclePowerCore PowerCore;
+
         protected UpgradedVehicle(
             string nameID,
             string friendlyName,
             string description,
             TechType template,
             float healthModifier,
-            TechType requiredAnalysis)
-            : base(nameID, friendlyName, description, template, CraftTree.Type.Constructor, "Vehicles", requiredAnalysis, TechGroup.Constructor, TechCategory.Constructor)
+            TechType requiredAnalysis,
+            VehiclePowerCore powerCore)
+            : base(
+                  nameID: nameID,
+                  friendlyName: friendlyName,
+                  description: description,
+                  template: template,
+                  fabricatorType: CraftTree.Type.Constructor,
+                  fabricatorTab: "Vehicles",
+                  requiredAnalysis: requiredAnalysis,
+                  groupForPDA: TechGroup.Constructor,
+                  categoryForPDA: TechCategory.Constructor)
         {
             HealthModifier = healthModifier;
+            PowerCore = powerCore;
+        }
+
+        protected override void PrePatch()
+        {
+            if (!PowerCore.IsPatched)
+                PowerCore.Patch();
         }
 
         public override GameObject GetGameObject()

--- a/UpgradedVehicles/Craftables/VehiclePowerCore.cs
+++ b/UpgradedVehicles/Craftables/VehiclePowerCore.cs
@@ -18,15 +18,10 @@
                   fabricatorTab: "CommonModules",
                   requiredAnalysis: TechType.BaseUpgradeConsole,
                   groupForPDA: TechGroup.Resources,
-                  categoryForPDA: TechCategory.Electronics)
+                  categoryForPDA: TechCategory.Electronics,
+                  prerequisite: speedBoostModule)
         {
             SpeedBoosterModule = speedBoostModule;
-        }
-
-        protected override void PrePatch()
-        {
-            if (!SpeedBoosterModule.IsPatched)
-                SpeedBoosterModule.Patch();
         }
 
         protected override void PostPatch()

--- a/UpgradedVehicles/Craftables/VehiclePowerCore.cs
+++ b/UpgradedVehicles/Craftables/VehiclePowerCore.cs
@@ -7,9 +7,7 @@
 
     internal class VehiclePowerCore : Craftable
     {
-        public static TechType TechTypeID { get; private set; }
-        
-        internal readonly TechType SpeedBoosterID;
+        protected readonly SpeedBooster SpeedBoosterModule;
 
         internal VehiclePowerCore(SpeedBooster speedBoostModule)
              : base(nameID: "VehiclePowerCore",
@@ -22,14 +20,19 @@
                   groupForPDA: TechGroup.Resources,
                   categoryForPDA: TechCategory.Electronics)
         {
-            SpeedBoosterID = speedBoostModule.TechType;
+            SpeedBoosterModule = speedBoostModule;
         }
 
-        public override void Patch()
+        protected override void PrePatch()
         {
-            base.Patch();
+            if (!SpeedBoosterModule.IsPatched)
+                SpeedBoosterModule.Patch();
+        }
+
+        protected override void PostPatch()
+        {
             CraftDataHandler.SetEquipmentType(this.TechType, EquipmentType.None);
-            TechTypeID = this.TechType;
+            MTechType.VehiclePowerCore = this.TechType;
         }
 
         protected override TechData GetRecipe()
@@ -44,8 +47,8 @@
                                  new Ingredient(TechType.PowerCell, 1),
 
                                  new Ingredient(TechType.VehiclePowerUpgradeModule, 2), // Engine eficiency
-                                 new Ingredient(TechType.VehicleArmorPlating, 2), // Armor                                 
-                                 new Ingredient(SpeedBoosterID, 2), // Speed boost
+                                 new Ingredient(TechType.VehicleArmorPlating, 2), // Armor
+                                 new Ingredient(SpeedBoosterModule.TechType, 2), // Speed boost
                              })
             };
         }
@@ -57,6 +60,6 @@
             GameObject.DestroyImmediate(obj.GetComponent<Battery>());
 
             return obj;
-        }        
+        }
     }
 }

--- a/UpgradedVehicles/EmUnlockConfig.cs
+++ b/UpgradedVehicles/EmUnlockConfig.cs
@@ -1,0 +1,72 @@
+﻿namespace UpgradedVehicles
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Common;
+    using Common.EasyMarkup;
+
+    internal class EmUnlockConfig : EmYesNo
+    {
+        private const string ConfigFile = "./QMods/UpgradedVehicles/Config.txt";
+
+        public EmUnlockConfig() : base("ForceUnlockAtStart", false)
+        {
+        }
+
+        private void WriteConfigFile()
+        {
+            File.WriteAllLines(ConfigFile, new[]
+            {
+                "# ----------------------------------------------------------------------------- #",
+                "# Changes to this config file will only take effect next time you boot the game #",
+                "#                 This config file was built using EasyMarkup                   #",
+                "# ----------------------------------------------------------------------------- #",
+                "",
+                this.PrettyPrint(),
+                "",
+                "# Here's what this configuration does: #",
+                "",
+                $"# 'Force Unlock At Start' #",
+                "# When this is set to 'NO', the new vehicles and items added by this mod will be unlocked normally as you discover the prerequisit blueprints. #",
+                "# Set this to 'YES' if you really want to have these new blueprints unlocked at the start of the game. #",
+                "# If you installed this mod on a game you had currently in progress and you are having issues unlocking the new vehicles, set this to 'YES' #",
+                "# ----------------------------------------------------------------------------- #",
+            }, Encoding.UTF8);
+        }
+
+        internal void Initialize()
+        {
+            try
+            {
+                LoadFromFile();
+            }
+            catch (Exception ex)
+            {
+                QuickLogger.Error("EXCEPTION LOADING {ConfigKey}: " + ex.ToString());
+                WriteConfigFile();
+            }
+        }
+
+        private void LoadFromFile()
+        {
+            if (!File.Exists(ConfigFile))
+            {
+                QuickLogger.Message("Mod config file not found. Writing default file.");
+                WriteConfigFile();
+                return;
+            }
+
+            string text = File.ReadAllText(ConfigFile, Encoding.UTF8);
+
+            bool readCorrectly = this.FromString(text);
+
+            if (!readCorrectly || !this.HasValue)
+            {
+                QuickLogger.Warning("Mod config file contained error. Writing default file.");
+                WriteConfigFile();
+                return;
+            }
+        }
+    }
+}

--- a/UpgradedVehicles/EmUnlockConfig.cs
+++ b/UpgradedVehicles/EmUnlockConfig.cs
@@ -10,6 +10,19 @@
     {
         private const string ConfigFile = "./QMods/UpgradedVehicles/Config.txt";
 
+        internal bool ForceUnlockAtStart
+        {
+            get
+            {
+                if (!Initialized)
+                    Initialize();
+
+                return this.Value;
+            }
+        }
+
+        internal bool Initialized { get; private set; } = false;
+
         public EmUnlockConfig() : base("ForceUnlockAtStart", false)
         {
         }
@@ -45,6 +58,15 @@
             {
                 QuickLogger.Error("EXCEPTION LOADING {ConfigKey}: " + ex.ToString());
                 WriteConfigFile();
+            }
+            finally
+            {
+                Initialized = true;
+
+                if (this.Value)
+                    QuickLogger.Message("ForceUnlockAtStart was enabled. New items will start unlocked.");
+                else
+                    QuickLogger.Message("New items set to normal unlock requirements.");
             }
         }
 

--- a/UpgradedVehicles/EmUnlockConfig.cs
+++ b/UpgradedVehicles/EmUnlockConfig.cs
@@ -10,6 +10,8 @@
     {
         private const string ConfigFile = "./QMods/UpgradedVehicles/Config.txt";
 
+        private const string ConfigKey = "ForceUnlockAtStart";
+
         internal bool ForceUnlockAtStart
         {
             get
@@ -23,8 +25,9 @@
 
         internal bool Initialized { get; private set; } = false;
 
-        public EmUnlockConfig() : base("ForceUnlockAtStart", false)
+        public EmUnlockConfig() : base(ConfigKey, false)
         {
+            base.ForceWrite = true;
         }
 
         private void WriteConfigFile()
@@ -56,7 +59,7 @@
             }
             catch (Exception ex)
             {
-                QuickLogger.Error("EXCEPTION LOADING {ConfigKey}: " + ex.ToString());
+                QuickLogger.Error($"EXCEPTION LOADING {ConfigKey}: " + ex.ToString());
                 WriteConfigFile();
             }
             finally

--- a/UpgradedVehicles/MTechType.cs
+++ b/UpgradedVehicles/MTechType.cs
@@ -1,0 +1,13 @@
+﻿namespace UpgradedVehicles
+{
+    internal static class MTechType
+    {
+        internal static TechType SpeedBooster { get; set; } = TechType.UnusedOld;
+        internal static TechType VehiclePowerCore { get; set; } = TechType.UnusedOld;
+        internal static TechType SeaMothMk2 { get; set; } = TechType.UnusedOld;
+        internal static TechType ExosuitMk2 { get; set; } = TechType.UnusedOld;
+        internal static TechType SeaMothMk3 { get; set; } = TechType.UnusedOld;
+        internal static TechType SeamothHullModule4 { get; set; } = TechType.UnusedOld;
+        internal static TechType SeamothHullModule5 { get; set; } = TechType.UnusedOld;
+    }
+}

--- a/UpgradedVehicles/MTechType.cs
+++ b/UpgradedVehicles/MTechType.cs
@@ -2,6 +2,8 @@
 {
     internal static class MTechType
     {
+        internal const int Count = 7;
+
         internal static TechType SpeedBooster { get; set; } = TechType.UnusedOld;
         internal static TechType VehiclePowerCore { get; set; } = TechType.UnusedOld;
         internal static TechType SeaMothMk2 { get; set; } = TechType.UnusedOld;

--- a/UpgradedVehicles/Patchers/Exosuit_Patcher.cs
+++ b/UpgradedVehicles/Patchers/Exosuit_Patcher.cs
@@ -33,7 +33,7 @@
         {
             var techType = __instance.GetComponent<TechTag>().type;
 
-            if (techType == ExosuitMk2.TechTypeID)
+            if (techType == MTechType.ExosuitMk2)
             {
                 __result = "PRAWN SUIT MK2";
                 return false;

--- a/UpgradedVehicles/Patchers/SeaMoth_Patcher.cs
+++ b/UpgradedVehicles/Patchers/SeaMoth_Patcher.cs
@@ -1,7 +1,6 @@
 ﻿namespace UpgradedVehicles.Patchers
 {
     using Harmony;
-    using UnityEngine;
 
     [HarmonyPatch(typeof(SeaMoth))]
     [HarmonyPatch("OnUpgradeModuleChange")]
@@ -34,12 +33,12 @@
         {
             var techType = __instance.GetComponent<TechTag>().type;
 
-            if (techType == SeaMothMk2.TechTypeID)
+            if (techType == MTechType.SeaMothMk2)
             {
                 __result = "SEAMOTH MK2";
                 return false;
             }
-            else if (techType == SeaMothMk3.TechTypeID)
+            else if (techType == MTechType.SeaMothMk3)
             {
                 __result = "SEAMOTH MK3";
                 return false;

--- a/UpgradedVehicles/QPatch.cs
+++ b/UpgradedVehicles/QPatch.cs
@@ -13,28 +13,14 @@
             {
                 QuickLogger.Message("Started patching");
 
-                var unlockConfig = new EmUnlockConfig();
-                unlockConfig.Initialize();
+                var speedBoost = Craftable.AddForPatching(new SpeedBooster());
+                var vpowerCore = Craftable.AddForPatching(new VehiclePowerCore(speedBoost));
+                var seamothMk2 = Craftable.AddForPatching(new SeaMothMk2(vpowerCore));
+                var exosuitMk2 = Craftable.AddForPatching(new ExosuitMk2(vpowerCore));
+                var seamothMk3 = Craftable.AddForPatching(new SeaMothMk3(vpowerCore));
 
-                Craftable.ForceUnlockAtStart = unlockConfig.Value;
-
-                if (Craftable.ForceUnlockAtStart)
-                    QuickLogger.Message("ForceUnlockAtStart was enabled. New items will start unlocked.");
-                else
-                    QuickLogger.Message("New items set to normal unlock requirements.");
-
-                var speedModule = new SpeedBooster();
-                var powerCore = new VehiclePowerCore(speedModule);
-                var mothMk2 = new SeaMothMk2(powerCore);
-                var suitMk2 = new ExosuitMk2(powerCore);
-                var mothMk3 = new SeaMothMk3(powerCore);
-
-                speedModule.Patch();
-                powerCore.Patch();
-                mothMk2.Patch();
-                suitMk2.Patch();
-                mothMk3.Patch();
-
+                Craftable.PatchAll();
+                
                 HarmonyInstance harmony = HarmonyInstance.Create("com.upgradedvehicles.psmod");
                 harmony.PatchAll(Assembly.GetExecutingAssembly());
 

--- a/UpgradedVehicles/QPatch.cs
+++ b/UpgradedVehicles/QPatch.cs
@@ -2,40 +2,47 @@
 {
     using System;
     using System.Reflection;
+    using Common;
     using Harmony;
 
     public class QPatch
     {
         public static void Patch()
         {
-
             try
             {
-                Console.WriteLine($"[UpgradedVehicles] Start patching");
+                QuickLogger.Message("Started patching");
+
+                var unlockConfig = new EmUnlockConfig();
+                unlockConfig.Initialize();
+
+                Craftable.ForceUnlockAtStart = unlockConfig.Value;
+
+                if (Craftable.ForceUnlockAtStart)
+                    QuickLogger.Message("ForceUnlockAtStart was enabled. New items will start unlocked.");
+                else
+                    QuickLogger.Message("New items set to normal unlock requirements.");
 
                 var speedModule = new SpeedBooster();
-                speedModule.Patch();
-
                 var powerCore = new VehiclePowerCore(speedModule);
-                powerCore.Patch();
-
                 var mothMk2 = new SeaMothMk2(powerCore);
-                mothMk2.Patch();
-
                 var suitMk2 = new ExosuitMk2(powerCore);
-                suitMk2.Patch();
-
                 var mothMk3 = new SeaMothMk3(powerCore);
+
+                speedModule.Patch();
+                powerCore.Patch();
+                mothMk2.Patch();
+                suitMk2.Patch();
                 mothMk3.Patch();
 
                 HarmonyInstance harmony = HarmonyInstance.Create("com.upgradedvehicles.psmod");
                 harmony.PatchAll(Assembly.GetExecutingAssembly());
 
-                Console.WriteLine($"[UpgradedVehicles] Finish patching");
+                QuickLogger.Message("Finished patching");
             }
             catch (Exception ex)
             {
-                Console.WriteLine("[UpgradedVehicles] EXCEPTION on Patch: " + ex.ToString());
+                QuickLogger.Error("EXCEPTION on Patch: " + ex.ToString());
             }
 
         }

--- a/UpgradedVehicles/UpgradedVehicles.csproj
+++ b/UpgradedVehicles/UpgradedVehicles.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Craftables\SpeedBooster.cs" />
     <Compile Include="Craftables\UpgradedVehicle.cs" />
     <Compile Include="Craftables\VehiclePowerCore.cs" />
+    <Compile Include="EmUnlockConfig.cs" />
+    <Compile Include="MTechType.cs" />
     <Compile Include="Patchers\CrushDamage_Patcher.cs" />
     <Compile Include="Patchers\DamageSystem_Patcher.cs" />
     <Compile Include="Patchers\Exosuit_Patcher.cs" />

--- a/UpgradedVehicles/VehicleUpgrader.cs
+++ b/UpgradedVehicles/VehicleUpgrader.cs
@@ -27,8 +27,8 @@
             if (techType != TechType.VehicleHullModule1 &&
                 techType != TechType.VehicleHullModule2 &&
                 techType != TechType.VehicleHullModule3 &&
-                techType != SeaMothMk3.SeamothHullModule4 &&
-                techType != SeaMothMk3.SeamothHullModule5)
+                techType != MTechType.SeamothHullModule4 &&
+                techType != MTechType.SeamothHullModule5)
             {
                 CrushDepthSet = true;
                 return; // Not a depth module. No need to update anything here.
@@ -41,7 +41,7 @@
         {
             TechType seamothType = seamoth.GetComponent<TechTag>().type;
 
-            if (seamothType != SeaMothMk2.TechTypeID && seamothType != SeaMothMk3.TechTypeID)
+            if (seamothType != MTechType.SeaMothMk2 && seamothType != MTechType.SeaMothMk3)
             {
                 CrushDepthSet = true;
                 ErrorMessage.AddMessage(Language.main.GetFormat("CrushDepthNow", seamoth.crushDamage.crushDepth));
@@ -50,9 +50,9 @@
 
             float minimumCrush = 0f;
 
-            if (seamothType == SeaMothMk2.TechTypeID)
+            if (seamothType == MTechType.SeaMothMk2)
                 minimumCrush = 700f;
-            else if (seamothType == SeaMothMk3.TechTypeID)
+            else if (seamothType == MTechType.SeaMothMk3)
                 minimumCrush = 1500f;
 
             OverrideCrushDepth(seamoth.crushDamage, BaseSeamothCrush, minimumCrush, announce);
@@ -73,7 +73,7 @@
 
         internal static void UpgradeExosuit(Exosuit exosuit, bool announce = false)
         {
-            bool isUpgradedExosuit = exosuit.GetComponent<TechTag>().type == ExosuitMk2.TechTypeID;
+            bool isUpgradedExosuit = exosuit.GetComponent<TechTag>().type == MTechType.ExosuitMk2;
 
             if (!isUpgradedExosuit)
             {
@@ -122,14 +122,14 @@
                 int armorModuleCount = GetModuleCount(vehicle.modules, TechType.VehicleArmorPlating, isUpgradedVehicle);
                 UpdateArmorRating(vehicle, armorModuleCount, true);
             }
-            else if (techType == SpeedBooster.TechTypeID || techType == TechType.VehiclePowerUpgradeModule) // Set power efficiency rating
+            else if (techType == MTechType.SpeedBooster|| techType == TechType.VehiclePowerUpgradeModule) // Set power efficiency rating
             {
-                int speedBoosterCount = GetModuleCount(vehicle.modules, SpeedBooster.TechTypeID, isUpgradedVehicle);
+                int speedBoosterCount = GetModuleCount(vehicle.modules, MTechType.SpeedBooster, isUpgradedVehicle);
                 int powerModuleCount = GetModuleCount(vehicle.modules, TechType.VehiclePowerUpgradeModule, isUpgradedVehicle);
 
                 UpdatePowerRating(vehicle, speedBoosterCount, powerModuleCount, true);
 
-                if (techType == SpeedBooster.TechTypeID) // Set speed rating
+                if (techType == MTechType.SpeedBooster) // Set speed rating
                 {
                     UpdateSpeedRating(vehicle, speedBoosterCount, true);
                 }
@@ -141,7 +141,7 @@
             bool isUpgradedVehicle = IsUpgradedVehicle(vehicle);
 
             int armorModuleCount = GetModuleCount(vehicle.modules, TechType.VehicleArmorPlating, isUpgradedVehicle);
-            int speedBoosterCount = GetModuleCount(vehicle.modules, SpeedBooster.TechTypeID, isUpgradedVehicle);
+            int speedBoosterCount = GetModuleCount(vehicle.modules, MTechType.SpeedBooster, isUpgradedVehicle);
             int powerModuleCount = GetModuleCount(vehicle.modules, TechType.VehiclePowerUpgradeModule, isUpgradedVehicle);
 
             // Set armor rating
@@ -158,9 +158,9 @@
         {
             TechType vehicleTechType = vehicle.GetComponent<TechTag>().type;
 
-            bool isUpgradedVehicle = vehicleTechType == SeaMothMk2.TechTypeID ||
-                                     vehicleTechType == ExosuitMk2.TechTypeID ||
-                                     vehicleTechType == SeaMothMk3.TechTypeID; // This one will be a nonsense TechType if it wasn't added
+            bool isUpgradedVehicle = vehicleTechType == MTechType.SeaMothMk2 ||
+                                     vehicleTechType == MTechType.ExosuitMk2 ||
+                                     vehicleTechType == MTechType.SeaMothMk3; // This one will be a nonsense TechType if it wasn't added
             return isUpgradedVehicle;
         }
 
@@ -174,11 +174,6 @@
             float speedMultiplier = 1f + speedBoosterCount * SpeedBonusPerModule;
 
             vehicle.forwardForce = speedMultiplier * ForwardForce;
-            //vehicle.backwardForce = speedMultiplier * BackwardForce;
-            //vehicle.sidewardForce = speedMultiplier * SidewardForce;
-
-            //vehicle.sidewaysTorque = speedMultiplier * SidewaysTorque;
-            //vehicle.verticalForce = speedMultiplier * VerticalForce;
             vehicle.onGroundForceMultiplier = speedMultiplier * OnGroundForceMultiplier;
 
             var motor = vehicle.GetComponent<VehicleMotor>();

--- a/UpgradedVehicles/mod.json
+++ b/UpgradedVehicles/mod.json
@@ -2,7 +2,7 @@
   "Id": "UpgradedVehicles",
   "DisplayName": "UpgradedVehicles",
   "Author": "PrimeSonic",
-  "Version": "2.0.3",
+  "Version": "2.0.4",
   "Requires": [ ],
   "Enable": true,
   "AssemblyName": "UpgradedVehicles.dll",

--- a/Utilities/EasyMarkup/EmProperty.cs
+++ b/Utilities/EasyMarkup/EmProperty.cs
@@ -80,7 +80,12 @@
 
         public string PrettyPrint()
         {
-            var originalString = new StringBuffer(this.ToString());
+            string originalValue = this.ToString();
+
+            if (string.IsNullOrEmpty(originalValue))
+                return string.Empty;
+
+            var originalString = new StringBuffer(originalValue);
 
             var prettyString = new StringBuffer();
 
@@ -121,6 +126,10 @@
 
                         prettyString.PushToEnd('\r', '\n');
                         prettyString.PushToEnd(' ', indentLevel * indentSize);
+                        break;
+                    case SpChar_KeyDelimiter:
+                        prettyString.PushToEnd(originalString.PopFromStart());
+                        prettyString.PushToEnd(' '); // Add a space after every KeyDelilmiter
                         break;
                     default:
                         prettyString.PushToEnd(originalString.PopFromStart());

--- a/Utilities/EasyMarkup/EmPropertyT.cs
+++ b/Utilities/EasyMarkup/EmPropertyT.cs
@@ -38,7 +38,6 @@
             if (string.IsNullOrEmpty(InLineComment))
                 return base.ToString();
 
-
             return $"{Key}{SpChar_KeyDelimiter}{SerializedValue}{SpChar_ValueDelimiter} {EmUtils.CommentText(InLineComment)}";
         }
 

--- a/Utilities/QuickLogger.cs
+++ b/Utilities/QuickLogger.cs
@@ -6,7 +6,7 @@
 
     internal static class QuickLogger
     {
-        public static void Message(string msg, bool showOnScreen = true)
+        public static void Message(string msg, bool showOnScreen = false)
         {
             string name = Assembly.GetCallingAssembly().GetName().Name;
 
@@ -16,7 +16,7 @@
                 ErrorMessage.AddMessage(msg);
         }
 
-        public static void Debug(string msg, bool showOnScreen = true)
+        public static void Debug(string msg, bool showOnScreen = false)
         {
             string name = Assembly.GetCallingAssembly().GetName().Name;
 
@@ -26,7 +26,7 @@
                 ErrorMessage.AddDebug(msg);
         }
 
-        public static void Error(string msg, bool showOnScreen = true)
+        public static void Error(string msg, bool showOnScreen = false)
         {
             string name = Assembly.GetCallingAssembly().GetName().Name;
 
@@ -36,7 +36,7 @@
                 ErrorMessage.AddError(msg);
         }
 
-        public static void Warning(string msg, bool showOnScreen = true)
+        public static void Warning(string msg, bool showOnScreen = false)
         {
             string name = Assembly.GetCallingAssembly().GetName().Name;
 


### PR DESCRIPTION
- Enables a config option to force the new items in UpgradedVehicles to be unlocked at start
- Defaults to NO
- Rework and cleanup of the patching process
- Moved all static TechType references into a single static class to mimic the usage of the TechType enum