### PR TITLE
MoreCyclopsUpgrades - Fixing the remaining cloned fabricators

### DIFF
--- a/MoreCyclopsUpgrades/Buildables/NuclearFabricator.cs
+++ b/MoreCyclopsUpgrades/Buildables/NuclearFabricator.cs
@@ -89,13 +89,19 @@
             prefab.name = NameID;
 
             // Add prefab ID
-            PrefabIdentifier prefabId = prefab.AddComponent<PrefabIdentifier>();
-            prefabId.ClassId = NameID;
-            prefabId.name = FriendlyName;
+            PrefabIdentifier prefabId = prefab.GetComponent<PrefabIdentifier>();
+            if (prefabId != null)
+            {
+                prefabId.ClassId = NameID;
+                prefabId.name = FriendlyName;
+            }
 
             // Add tech tag
-            TechTag techTag = prefab.AddComponent<TechTag>();
-            techTag.type = this.TechType;
+            TechTag techTag = prefab.GetComponent<TechTag>();
+            if (techTag != null)
+            {
+                techTag.type = this.TechType;
+            }
 
             // Update sky applier
             SkyApplier skyApplier = prefab.GetComponent<SkyApplier>();

--- a/MoreCyclopsUpgrades/Modules/Recharging/Nuclear/DepletedNuclearModule.cs
+++ b/MoreCyclopsUpgrades/Modules/Recharging/Nuclear/DepletedNuclearModule.cs
@@ -53,7 +53,7 @@
                 SetStaticTechTypeID(this.TechType);
             }
 
-            //this.NukFabricator.Patch(CyclopsModule.ModulesEnabled);
+            this.NukFabricator.Patch(CyclopsModule.ModulesEnabled);
         }
 
         protected override TechData GetRecipe()

--- a/MoreCyclopsUpgrades/Modules/Recharging/Nuclear/DepletedNuclearModule.cs
+++ b/MoreCyclopsUpgrades/Modules/Recharging/Nuclear/DepletedNuclearModule.cs
@@ -53,7 +53,7 @@
                 SetStaticTechTypeID(this.TechType);
             }
 
-            this.NukFabricator.Patch(CyclopsModule.ModulesEnabled);
+            //this.NukFabricator.Patch(CyclopsModule.ModulesEnabled);
         }
 
         protected override TechData GetRecipe()

--- a/MoreCyclopsUpgrades/Patchers/SubRoot_Patcher.cs
+++ b/MoreCyclopsUpgrades/Patchers/SubRoot_Patcher.cs
@@ -44,7 +44,7 @@
         {
             var cyclopsLife = (LiveMixin)__instance.GetInstanceField("live");
 
-            if (!cyclopsLife.IsAlive())
+            if (cyclopsLife is null || !cyclopsLife.IsAlive())
                 return true; // safety check
 
             if (!UpgradeConsoleCache.IsSynced(__instance)) // Because this might run before CyclopsUpgradeConsoleHUDManager.RefreshScreen

--- a/MoreCyclopsUpgrades/PowerManager.cs
+++ b/MoreCyclopsUpgrades/PowerManager.cs
@@ -247,7 +247,7 @@
                 }
             }
 
-            CyclopsDoneCharging = Mathf.Approximately(PowerDeficit, 0f);
+            CyclopsDoneCharging = PowerDeficit <= 0.001f;
 
             if (UpgradeConsoleCache.HasNuclearModules && // Handle nuclear power
                 !CyclopsDoneCharging && // Halt charging if Cyclops is on full charge

--- a/MoreCyclopsUpgrades/PowerManager.cs
+++ b/MoreCyclopsUpgrades/PowerManager.cs
@@ -75,6 +75,7 @@
         private static float AvailableThermalEnergy = 0f;
         private static float SurplusPower = 0f;
         private static bool RenewablePowerAvailable = false;
+        private static bool CyclopsDoneCharging = false;
         private static Battery LastBatteryToCharge = null;
 
         /// <summary>
@@ -246,7 +247,10 @@
                 }
             }
 
+            CyclopsDoneCharging = Mathf.Approximately(PowerDeficit, 0f);
+
             if (UpgradeConsoleCache.HasNuclearModules && // Handle nuclear power
+                !CyclopsDoneCharging && // Halt charging if Cyclops is on full charge
                 PowerDeficit > NuclearModuleConfig.MinimumEnergyDeficit && // User config for threshold to start charging
                 !RenewablePowerAvailable) // Only if there's no renewable power available
             {
@@ -259,7 +263,7 @@
             }
 
             // If the Cyclops is at full energy and it's generating a surplus of power, it can recharge a reserve battery
-            if (Mathf.Approximately(PowerDeficit, 0f) && SurplusPower > 0f && LastBatteryToCharge != null)
+            if (CyclopsDoneCharging && SurplusPower > 0f && LastBatteryToCharge != null)
             {
                 // Recycle surplus power back into the batteries that need it
                 LastBatteryToCharge.charge = Mathf.Min(LastBatteryToCharge.capacity, LastBatteryToCharge.charge + SurplusPower);

--- a/MoreCyclopsUpgrades/PowerManager.cs
+++ b/MoreCyclopsUpgrades/PowerManager.cs
@@ -455,7 +455,7 @@
             GameObject gameObject = GameObject.Instantiate(prefab);
 
             gameObject.GetComponent<PrefabIdentifier>().ClassId = DepletedNuclearModule.DepletedNameID;
-            gameObject.AddComponent<TechTag>().type = CyclopsModule.DepletedNuclearModuleID;
+            gameObject.GetComponent<TechTag>().type = CyclopsModule.DepletedNuclearModuleID;
 
             Pickupable pickupable = gameObject.GetComponent<Pickupable>().Pickup(false);
             return new InventoryItem(pickupable);

--- a/MoreCyclopsUpgrades/Properties/AssemblyInfo.cs
+++ b/MoreCyclopsUpgrades/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.6.0")]
-[assembly: AssemblyFileVersion("2.1.6.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]
 [assembly: InternalsVisibleTo("MoreCyclopsUpgradesTests")]

--- a/MoreCyclopsUpgrades/mod.json
+++ b/MoreCyclopsUpgrades/mod.json
@@ -2,7 +2,7 @@
   "Id": "MoreCyclopsUpgrades",
   "DisplayName": "MoreCyclopsUpgrades",
   "Author": "PrimeSonic",
-  "Version": "2.1.7",
+  "Version": "2.1.8",
   "Requires": [ ],
   "Enable": true,
   "AssemblyName": "MoreCyclopsUpgrades.dll",


### PR DESCRIPTION
Binary files for 2.1.8 beta. Use this after removing the remaining nuclear fabricator clones.
[MoreCyclopsUpgrades_218beta.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/2363499/MoreCyclopsUpgrades_218beta.zip)

This modified DLL will avoid patching in the nuclear fabricator. 
[MoreCyclopsUpgrades_destroyNukFabs.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/2363500/MoreCyclopsUpgrades_destroyNukFabs.zip)
This means that once the game is loaded, all nuclear fabricators simply will cease to exist.
This way you don't have to waste time deconstructing the remaining duplicates.
After you've loaded the game, save and quit. You can then go ahead and start using the 2.1.8 beta files.

-- EDIT --
This file contains the existing updates for the nuclear fabricator clone fix plus also a minor change to help mitigate power leaks on nuclear batteries.
[MoreCyclopsUpgrades_powerleakBeta.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/2364360/MoreCyclopsUpgrades_powerleakBeta.zip)
-- EDIT -- 
Second version of the power leak fix 
[MoreCyclopsUpgrades_powerleakV2.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/2364955/MoreCyclopsUpgrades_powerleakV2.zip)



