### PR TITLE
Changes to Speed Boost Engine Efficiency penalty

### DIFF
--- a/UpgradedVehicles/VehicleUpgrader.cs
+++ b/UpgradedVehicles/VehicleUpgrader.cs
@@ -161,12 +161,12 @@
                 return 1f;
 
             if (this.IsExosuit)
-                return 1f + (0.15f * speedBoosterCount);
+                return 1f + (1.15f * speedBoosterCount);
 
             if (this.IsSeamoth)
-                return 1f + (0.10f * speedBoosterCount);
+                return 1f + (1.10f * speedBoosterCount);
 
-            return 1f + (0.125f * speedBoosterCount);
+            return 1f + (1.125f * speedBoosterCount);
         }
 
         private float EfficiencyBonus(int powerModuleCount)
@@ -174,7 +174,7 @@
             if (powerModuleCount == 0)
                 return 1f;
 
-            return 1f + (0.15f * powerModuleCount);
+            return 1f + powerModuleCount;
         }
 
         private float ExtraEfficiencyBonus()

--- a/UpgradedVehicles/VehicleUpgrader.cs
+++ b/UpgradedVehicles/VehicleUpgrader.cs
@@ -161,12 +161,12 @@
                 return 1f;
 
             if (this.IsExosuit)
-                return 1.15f * speedBoosterCount;
+                return 1f + (0.15f * speedBoosterCount);
 
             if (this.IsSeamoth)
-                return 1.10f * speedBoosterCount;
+                return 1f + (0.10f * speedBoosterCount);
 
-            return 1f * speedBoosterCount;
+            return 1f + (0.125f * speedBoosterCount);
         }
 
         private float EfficiencyBonus(int powerModuleCount)
@@ -174,7 +174,7 @@
             if (powerModuleCount == 0)
                 return 1f;
 
-            return 1f + powerModuleCount;
+            return 1f + (0.15f * powerModuleCount);
         }
 
         private float ExtraEfficiencyBonus()


### PR DESCRIPTION
With more than 1 speedbooster, the EfficiencyPentalty would be huge.  I split the difference on the catchall as that is what you did for the SpeedBonus.  The Engine Efficiency module was acting like it added +100% efficiency per module instead of the +15% that is listed in the wiki.