### PR TITLE
Adding QuickSlotType to Speed Booster Module

### DIFF
--- a/UpgradedVehicles/Craftables/SpeedBooster.cs
+++ b/UpgradedVehicles/Craftables/SpeedBooster.cs
@@ -28,7 +28,11 @@
             base.OnFinishedPatching += PostPatch;
         }
 
-        private void PostPatch() => CraftDataHandler.SetEquipmentType(this.TechType, EquipmentType.VehicleModule);
+        private void PostPatch()
+        {
+            CraftDataHandler.SetEquipmentType(this.TechType, EquipmentType.VehicleModule);
+            CraftDataHandler.SetQuickSlotType(this.TechType, QuickSlotType.Passive);
+        }
 
         protected override TechData GetBlueprintRecipe() => new TechData()
         {


### PR DESCRIPTION
Without the QuickSlotType set to passive, the Speed Booster has a transparent background on the quick slot bar instead of the always blue background of passives. 
https://github.com/SMLHelper/SMLHelper/wiki/Editing-an-item's-quick-slot-type
NOTE: Javascript is not one of my primary languages, so please double check the syntax.