### PR TITLE
CyclopsEnhancedSonar 

### DIFF
--- a/CyclopsEnhancedSonar/CySonarComponent.cs
+++ b/CyclopsEnhancedSonar/CySonarComponent.cs
@@ -1,0 +1,98 @@
+﻿namespace CyclopsEnhancedSonar
+{
+    using System;
+    using System.Collections.Generic;
+    using UnityEngine;
+
+    // Code adapted from the original CyclopsNearFieldSonar mod by frigidpenguin
+    internal class CySonarComponent : MonoBehaviour
+    {
+        private static IEnumerator<YieldInstruction> EachFrameUntil(Func<bool> action)
+        {
+            while (!action())
+            {
+                yield return null;
+            }
+        }
+
+        private static readonly GameObject template = Resources.Load<GameObject>("WorldEntities/Tools/SeaGlide");
+
+        public void SetMapState(bool state)
+        {
+            if (state)
+                script?.EnableMap();
+            else
+                script?.DisableMap();
+        }
+
+        private const float scale = 6.699605f;
+        private const float fadeRadius = 1.503953f;
+        private const float shipScale = 0.2f;
+        private readonly Vector3 position = new Vector3(-0.9762846f, 2, -10.6917f);
+        private readonly Vector3 shipPosition = new Vector3(0, 0, 0);
+
+        private VehicleInterface_Terrain script;
+        private Material material;
+        private GameObject ship;
+
+        private void Start()
+        {
+            Transform root = this.gameObject.transform.Find("SonarMap_Small");
+            var holder = new GameObject("NearFieldSonar");
+            holder.transform.SetParent(root, false);
+            holder.transform.localScale = Vector3.one * 0.1f;
+
+            GameObject prefab = template.GetComponent<VehicleInterface_MapController>().interfacePrefab;
+            var hologram = GameObject.Instantiate(prefab);
+            hologram.transform.SetParent(holder.transform, false);
+
+            script = hologram.GetComponentInChildren<VehicleInterface_Terrain>();
+            script.active = true;
+            script.EnableMap();
+
+            StartCoroutine(EachFrameUntil(() =>
+            {
+                material = script.materialInstance;
+                return UpdateParameters();
+            }));
+
+            ship = GameObject.Instantiate(this.gameObject.transform.Find("HolographicDisplay/CyclopsMini_Mid").gameObject);
+            ship.transform.SetParent(root, false);
+
+            MeshRenderer[] cyclopsMeshRenderers = ship.transform.GetComponentsInChildren<MeshRenderer>();
+
+            foreach (MeshRenderer meshRenderer in cyclopsMeshRenderers)
+            {
+                if (meshRenderer.gameObject.name.StartsWith("cyclops_room_"))
+                {
+                    meshRenderer.enabled = false;
+                }
+            }
+
+            MeshRenderer oldShipRenderer = root.Find("CyclopsMini").GetComponent<MeshRenderer>();
+            Material shipMaterial = oldShipRenderer.material;
+
+            foreach (MeshRenderer meshRenderer in cyclopsMeshRenderers)
+                meshRenderer.sharedMaterial = shipMaterial;
+
+            oldShipRenderer.enabled = false;
+            root.Find("Base").GetComponent<MeshRenderer>().enabled = false;
+        }
+
+        private bool UpdateParameters()
+        {
+            if (material == null)
+                return false;
+
+            script.hologramHolder.transform.localScale = Vector3.one * scale;
+            script.hologramHolder.transform.localPosition = position * (1 / scale);
+
+            material.SetFloat("_FadeRadius", fadeRadius);
+
+            ship.transform.localPosition = shipPosition;
+            ship.transform.localScale = Vector3.one * shipScale;
+
+            return true;
+        }
+    }
+}

--- a/CyclopsEnhancedSonar/CySonarComponent.cs
+++ b/CyclopsEnhancedSonar/CySonarComponent.cs
@@ -15,7 +15,7 @@
             }
         }
 
-        private static readonly GameObject template = Resources.Load<GameObject>("WorldEntities/Tools/SeaGlide");
+        private readonly GameObject template = CraftData.GetPrefabForTechType(TechType.Seaglide);
 
         public void SetMapState(bool state)
         {

--- a/CyclopsEnhancedSonar/CyclopsEnhancedSonar.csproj
+++ b/CyclopsEnhancedSonar/CyclopsEnhancedSonar.csproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E347C779-52A3-428A-AC51-D02E5C606562}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CyclopsEnhancedSonar</RootNamespace>
+    <AssemblyName>CyclopsEnhancedSonar</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony-1.2.0.1">
+      <HintPath>..\DependenciesSubnautica\0Harmony-1.2.0.1.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass_publicized">
+      <HintPath>..\DependenciesSubnautica\Assembly-CSharp-firstpass_publicized.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp_publicized">
+      <HintPath>..\DependenciesSubnautica\Assembly-CSharp_publicized.dll</HintPath>
+    </Reference>
+    <Reference Include="SMLHelper, Version=2.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\DependenciesSubnautica\SMLHelper.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\DependenciesSubnautica\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CySonarComponent.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QPatch.cs" />
+    <Compile Include="SonarPdaDisplay.cs" />
+    <Compile Include="SonarUpgradeHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="mod.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MoreCyclopsUpgrades\MoreCyclopsUpgrades.csproj">
+      <Project>{fc87af94-413d-482e-ab0d-501e120e6e2d}</Project>
+      <Name>MoreCyclopsUpgrades</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\CommonCyclopsUpgrades\CommonCyclopsUpgrades.projitems" Label="Shared" />
+  <Import Project="..\Utilities\Utilities.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CyclopsEnhancedSonar/Properties/AssemblyInfo.cs
+++ b/CyclopsEnhancedSonar/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CyclopsEnhancedSonar")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CyclopsEnhancedSonar")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e347c779-52a3-428a-ac51-d02e5c606562")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CyclopsEnhancedSonar/QPatch.cs
+++ b/CyclopsEnhancedSonar/QPatch.cs
@@ -1,0 +1,39 @@
+﻿namespace CyclopsEnhancedSonar
+{
+    using System;
+    using System.Reflection;
+    using Common;
+    using Harmony;
+    using MoreCyclopsUpgrades.API;
+
+    public static class QPatch
+    {
+        public static void Patch()
+        {
+            QuickLogger.Info($"Started patching. Version {QuickLogger.GetAssemblyVersion()}");
+
+            try
+            {                
+                MethodInfo subControlStartMethod = AccessTools.Method(typeof(SubControl), nameof(SubControl.Start));
+
+                var harmony = HarmonyInstance.Create("com.CyclopsEnhancedSonar.psmod");
+                harmony.Patch(subControlStartMethod, postfix: new HarmonyMethod(typeof(QPatch), nameof(QPatch.SubControlStartPostfix)));
+                
+                MCUServices.Register.CyclopsUpgradeHandler((SubRoot cyclops) => new SonarUpgradeHandler(cyclops));
+                MCUServices.Register.PdaIconOverlay(TechType.CyclopsSonarModule, (uGUI_ItemIcon icon, InventoryItem upgradeModule) => new SonarPdaDisplay(icon, upgradeModule));
+
+                QuickLogger.Info($"Finished patching.");
+            }
+            catch (Exception ex)
+            {
+                QuickLogger.Error(ex);
+            }
+        }
+
+        public static void SubControlStartPostfix(SubControl __instance)
+        {
+            if (__instance.gameObject.name.StartsWith("Cyclops-MainPrefab"))
+                __instance.gameObject.AddComponent<CySonarComponent>();
+        }
+    }
+}

--- a/CyclopsEnhancedSonar/SonarPdaDisplay.cs
+++ b/CyclopsEnhancedSonar/SonarPdaDisplay.cs
@@ -5,9 +5,16 @@
 
     internal class SonarPdaDisplay : IconOverlay
     {
+        public const string SpeedUpKey = "CySnrSpdUp";
+        public const string SpeedUpText = "Sonar Speed Up";
+
+        private readonly string langSpeedUpText;
+
         public SonarPdaDisplay(uGUI_ItemIcon icon, InventoryItem upgradeModule)
             : base(icon, upgradeModule)
         {
+            base.UpperText.FontSize = 12;
+            langSpeedUpText = Language.main.Get(SpeedUpKey);
         }
 
         public override void UpdateText()
@@ -16,6 +23,10 @@
 
             base.LowerText.FontSize = 14 + (3 * upgradeCount);
             base.LowerText.TextString = $"{upgradeCount}/{SonarUpgradeHandler.MaxUpgrades}";
+
+            base.UpperText.TextString = upgradeCount == SonarUpgradeHandler.MaxUpgrades 
+                ? $"[{langSpeedUpText}]" 
+                : string.Empty;
         }
     }
 }

--- a/CyclopsEnhancedSonar/SonarPdaDisplay.cs
+++ b/CyclopsEnhancedSonar/SonarPdaDisplay.cs
@@ -1,0 +1,21 @@
+﻿namespace CyclopsEnhancedSonar
+{
+    using MoreCyclopsUpgrades.API;
+    using MoreCyclopsUpgrades.API.PDA;
+
+    internal class SonarPdaDisplay : IconOverlay
+    {
+        public SonarPdaDisplay(uGUI_ItemIcon icon, InventoryItem upgradeModule)
+            : base(icon, upgradeModule)
+        {
+        }
+
+        public override void UpdateText()
+        {
+            int upgradeCount = MCUServices.CrossMod.GetUpgradeCount(base.Cyclops, TechType.CyclopsSonarModule);
+
+            base.LowerText.FontSize = 14 + (3 * upgradeCount);
+            base.LowerText.TextString = $"{upgradeCount}/{SonarUpgradeHandler.MaxUpgrades}";
+        }
+    }
+}

--- a/CyclopsEnhancedSonar/SonarUpgradeHandler.cs
+++ b/CyclopsEnhancedSonar/SonarUpgradeHandler.cs
@@ -26,8 +26,10 @@
                 // New behavior that toggles the near field sonar map
                 this.CySonar?.SetMapState(hasUpgrade);
 
-                if (hasUpgrade)
+                if (hasUpgrade && this.CyButton != null)
                 {
+                    // 1 sonar module = 5 seconds (vanilla)
+                    // 2 sonar modules = 3.9 seconds
                     float pinginterval = 6.1f - 1.1f * this.Count;
                     this.CyButton.pingIterationDuration = pinginterval;
                 }

--- a/CyclopsEnhancedSonar/SonarUpgradeHandler.cs
+++ b/CyclopsEnhancedSonar/SonarUpgradeHandler.cs
@@ -1,0 +1,37 @@
+﻿namespace CyclopsEnhancedSonar
+{
+    using MoreCyclopsUpgrades.API.Upgrades;
+
+    internal class SonarUpgradeHandler : UpgradeHandler
+    {
+        public const int MaxUpgrades = 2;
+
+        private CySonarComponent cySonar;
+        private CySonarComponent CySonar => cySonar ?? (cySonar = base.Cyclops.GetComponentInChildren<SubControl>()?.gameObject.GetComponent<CySonarComponent>());
+
+        private CyclopsSonarButton cyButton;
+        private CyclopsSonarButton CyButton => cyButton ?? (cyButton = base.Cyclops.GetComponentInChildren<CyclopsSonarButton>());
+
+        public SonarUpgradeHandler(SubRoot cyclops)
+            : base(TechType.CyclopsSonarModule, cyclops)
+        {
+            this.MaxCount = MaxUpgrades;
+            OnFinishedUpgrades = () =>
+            {
+                bool hasUpgrade = base.HasUpgrade;
+
+                // Vanilla behavior that toggles the sonar button
+                base.Cyclops.sonarUpgrade = hasUpgrade;
+
+                // New behavior that toggles the near field sonar map
+                this.CySonar?.SetMapState(hasUpgrade);
+
+                if (hasUpgrade)
+                {
+                    float pinginterval = 6.1f - 1.1f * this.Count;
+                    this.CyButton.pingIterationDuration = pinginterval;
+                }
+            };
+        }
+    }
+}

--- a/CyclopsEnhancedSonar/mod.json
+++ b/CyclopsEnhancedSonar/mod.json
@@ -1,7 +1,7 @@
 {
   "Id": "CyclopsEnhancedSonar",
   "DisplayName": "CyclopsEnhancedSonar",
-  "Author": "PrimeSonic",
+  "Author": "PrimeSonic & frigidpenguin",
   "Version": "1.0.0",
   "Enable": true,
   "Game": "Subnautica",

--- a/CyclopsEnhancedSonar/mod.json
+++ b/CyclopsEnhancedSonar/mod.json
@@ -1,0 +1,14 @@
+{
+  "Id": "CyclopsEnhancedSonar",
+  "DisplayName": "CyclopsEnhancedSonar",
+  "Author": "PrimeSonic",
+  "Version": "1.0.0",
+  "Enable": true,
+  "Game": "Subnautica",
+  "AssemblyName": "CyclopsEnhancedSonar.dll",
+  "Dependencies": [ "SMLHelper", "MoreCyclopsUpgrades" ],
+  "VersionDependencies": { "MoreCyclopsUpgrades": "4.1" },
+  "LoadBefore": [ "MoreCyclopsUpgrades" ],
+  "AssemblyName": "CyclopsEnhancedSonar.dll",
+  "EntryMethod": "CyclopsEnhancedSonar.QPatch.Patch"
+}

--- a/PrimeSonicSubnauticaMods.sln
+++ b/PrimeSonicSubnauticaMods.sln
@@ -52,6 +52,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CommonCyclopsBuildables", "
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FCStudioHelpers", "FCStudioHelpers\FCStudioHelpers.shproj", "{5C00A82E-51C7-4721-8052-5DD9A14C78AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CyclopsEnhancedSonar", "CyclopsEnhancedSonar\CyclopsEnhancedSonar.csproj", "{E347C779-52A3-428A-AC51-D02E5C606562}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Utilities\Utilities.projitems*{0845ceea-976e-4d0b-ae5d-7dbba6fe1476}*SharedItemsImports = 4
@@ -82,6 +84,8 @@ Global
 		FCStudioHelpers\FCStudioHelpers.projitems*{d390e5a9-2fff-48b8-acfc-9b49f0c1c4ce}*SharedItemsImports = 4
 		Utilities\Utilities.projitems*{d390e5a9-2fff-48b8-acfc-9b49f0c1c4ce}*SharedItemsImports = 4
 		CommonCyclopsUpgrades\CommonCyclopsUpgrades.projitems*{da01f903-5e97-47fc-a7e5-d67967d89646}*SharedItemsImports = 13
+		CommonCyclopsUpgrades\CommonCyclopsUpgrades.projitems*{e347c779-52a3-428a-ac51-d02e5c606562}*SharedItemsImports = 4
+		Utilities\Utilities.projitems*{e347c779-52a3-428a-ac51-d02e5c606562}*SharedItemsImports = 4
 		CommonCyclopsBuildables\CommonCyclopsBuildables.projitems*{fc87af94-413d-482e-ab0d-501e120e6e2d}*SharedItemsImports = 4
 		Utilities\Utilities.projitems*{fc87af94-413d-482e-ab0d-501e120e6e2d}*SharedItemsImports = 4
 		CommonCyclopsBuildables\CommonCyclopsBuildables.projitems*{fcb57595-3f3f-4ce0-a40f-bc161f367467}*SharedItemsImports = 13
@@ -159,6 +163,10 @@ Global
 		{7A11A1DB-09F4-44A5-BCD7-2CEAC6B1FEBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A11A1DB-09F4-44A5-BCD7-2CEAC6B1FEBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A11A1DB-09F4-44A5-BCD7-2CEAC6B1FEBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E347C779-52A3-428A-AC51-D02E5C606562}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E347C779-52A3-428A-AC51-D02E5C606562}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E347C779-52A3-428A-AC51-D02E5C606562}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E347C779-52A3-428A-AC51-D02E5C606562}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -176,6 +184,7 @@ Global
 		{7505FE7E-0ED8-48D6-ADCB-710DCD727CF2} = {8CE53864-B6EA-4EEA-A251-F8940719FA18}
 		{7A11A1DB-09F4-44A5-BCD7-2CEAC6B1FEBD} = {8CE53864-B6EA-4EEA-A251-F8940719FA18}
 		{FCB57595-3F3F-4CE0-A40F-BC161F367467} = {8CE53864-B6EA-4EEA-A251-F8940719FA18}
+		{E347C779-52A3-428A-AC51-D02E5C606562} = {8CE53864-B6EA-4EEA-A251-F8940719FA18}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE0C8D9E-28B2-4836-8250-A175A58A5566}


### PR DESCRIPTION
# CyclopsEnhancedSonar
Adapted from frigidpenguin's original [CyclopsNearFieldSonar](https://www.nexusmods.com/subnautica/mods/175) mod
- Adds a local map display to the helm similar to the seaglide
- Adding a second sonar upgrade will speed up the pings


Release package (beta): [CyclopsEnhancedSonar.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/3963519/CyclopsEnhancedSonar.zip)