### PR TITLE
UpgradedVehicles v3.4.0 - Static HP Values

### DIFF
--- a/UpgradedVehicles/Properties/AssemblyInfo.cs
+++ b/UpgradedVehicles/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.3.0")]
-[assembly: AssemblyFileVersion("3.3.3.0")]
+[assembly: AssemblyVersion("3.4.0.0")]
+[assembly: AssemblyFileVersion("3.4.0.0")]

--- a/UpgradedVehicles/mod.json
+++ b/UpgradedVehicles/mod.json
@@ -2,7 +2,7 @@
   "Id": "UpgradedVehicles",
   "DisplayName": "UpgradedVehicles",
   "Author": "PrimeSonic",
-  "Version": "3.3.3",
+  "Version": "3.4.0",
   "Enable": true,
   "AssemblyName": "UpgradedVehicles.dll",
   "Game": "Subnautica",


### PR DESCRIPTION
- Removes changes to Max Hit Points on upgrades
- Reworked the GeneralArmorFraction calculation to a more linear progression

Release Candidate pack: [UpgradedVehicles_340RC.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/4101185/UpgradedVehicles_340RC.zip)
