### PR TITLE
CustomCraftSML v1.8.4 bugfix

### DIFF
--- a/CustomCraftSML/Interfaces/InternalUse/ICustomCraft.cs
+++ b/CustomCraftSML/Interfaces/InternalUse/ICustomCraft.cs
@@ -6,6 +6,7 @@
     {
         string ID { get; }
         bool PassesPreValidation(OriginFile originFile);
+        bool PassedSecondValidation { get; }
         bool SendToSMLHelper();
 
         OriginFile Origin { get; set; }

--- a/CustomCraftSML/Interfaces/InternalUse/ICustomCraft.cs
+++ b/CustomCraftSML/Interfaces/InternalUse/ICustomCraft.cs
@@ -5,7 +5,7 @@
     internal interface ICustomCraft
     {
         string ID { get; }
-        bool PassesPreValidation();
+        bool PassesPreValidation(OriginFile originFile);
         bool SendToSMLHelper();
 
         OriginFile Origin { get; set; }

--- a/CustomCraftSML/Properties/AssemblyInfo.cs
+++ b/CustomCraftSML/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.8.3.0")]
-[assembly: AssemblyFileVersion("1.8.3.0")]
+[assembly: AssemblyVersion("1.8.4.0")]
+[assembly: AssemblyFileVersion("1.8.4.0")]
 
 [assembly: InternalsVisibleTo("CustomCraftSMLTests")]

--- a/CustomCraftSML/Serialization/Components/EmIngredient.cs
+++ b/CustomCraftSML/Serialization/Components/EmIngredient.cs
@@ -51,7 +51,7 @@
 
         internal override EmProperty Copy() => new EmIngredient(this.ItemID, this.Required);
 
-        public override bool PassesPreValidation() => base.PassesPreValidation() && RequireValueInRange();
+        public override bool PassesPreValidation(OriginFile originFile) => base.PassesPreValidation(originFile) && RequireValueInRange();
 
         private bool RequireValueInRange()
         {

--- a/CustomCraftSML/Serialization/Components/EmTechTyped.cs
+++ b/CustomCraftSML/Serialization/Components/EmTechTyped.cs
@@ -39,14 +39,14 @@
 
         public TechType TechType { get; set; } = TechType.None;
 
-        public virtual bool PassesPreValidation()
+        public virtual bool PassesPreValidation(OriginFile originFile)
         {
             // Now we can safely do the prepass check in case we need to create a new modded TechType
             this.TechType = GetTechType(this.ItemID);
 
             if (this.TechType == TechType.None)
             {
-                QuickLogger.Warning($"Could not resolve {ItemIdKey} value of '{this.ItemID}' for {this.Key}. Discarded entry.");
+                QuickLogger.Warning($"Could not resolve {ItemIdKey} value of '{this.ItemID}' for '{this.Key}' from file '{originFile}'. Discarded entry.");
                 return false;
             }
 

--- a/CustomCraftSML/Serialization/Entries/AliasRecipe.cs
+++ b/CustomCraftSML/Serialization/Entries/AliasRecipe.cs
@@ -97,7 +97,7 @@
             return new AliasRecipe(this.Key, this.CopyDefinitions);
         }
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
             return ItemIDisUnique() & // Confirm that no other item is currently using this ID.                                 
                 InnerItemsAreValid() &

--- a/CustomCraftSML/Serialization/Entries/CustomBioFuel.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomBioFuel.cs
@@ -40,6 +40,8 @@
 
         public OriginFile Origin { get; set; }
 
+        public bool PassedSecondValidation => true;
+
         public string ID => this.ItemID;
 
         public float Energy

--- a/CustomCraftSML/Serialization/Entries/CustomCraftingTab.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomCraftingTab.cs
@@ -110,6 +110,8 @@
 
         public string FullPath => $"{this.ParentTabPath}{"/"}{this.TabID}";
 
+        public bool PassedSecondValidation { get; set; } = true;
+
         internal override EmProperty Copy()
         {
             return new CustomCraftingTab(this.Key, this.CopyDefinitions);

--- a/CustomCraftSML/Serialization/Entries/CustomCraftingTab.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomCraftingTab.cs
@@ -115,7 +115,7 @@
             return new CustomCraftingTab(this.Key, this.CopyDefinitions);
         }
 
-        public bool PassesPreValidation()
+        public bool PassesPreValidation(OriginFile originFile)
         {
             return this.CraftingPath != null & ValidFabricator();
         }

--- a/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
@@ -1,5 +1,8 @@
 ﻿namespace CustomCraft2SML.Serialization.Entries
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Common;
     using Common.EasyMarkup;
     using CustomCraft2SML.Fabricators;
@@ -10,9 +13,6 @@
     using SMLHelper.V2.Crafting;
     using SMLHelper.V2.Handlers;
     using SMLHelper.V2.Utility;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
     using UnityEngine;
     using IOPath = System.IO.Path;
 
@@ -305,9 +305,9 @@
             }
             else
             {
-                QuickLogger.Debug($"Default sprite for {this.Key} '{this.ItemID}' from {this.Origin}");                
+                QuickLogger.Debug($"Default sprite for {this.Key} '{this.ItemID}' from {this.Origin}");
                 switch (this.Model)
-                {                    
+                {
                     case ModelTypes.Fabricator:
                         sprite = SpriteManager.Get(TechType.Fabricator);
                         break;
@@ -316,11 +316,11 @@
                         break;
                     case ModelTypes.MoonPool:
                         imagePath = IOPath.Combine(FileLocations.AssetsFolder, $"MoonPool.png");
-                        sprite = ImageUtils.LoadSpriteFromFile(imagePath);                        
+                        sprite = ImageUtils.LoadSpriteFromFile(imagePath);
                         break;
                     default:
                         throw new InvalidOperationException("Invalid ModelType encountered in HandleCustomSprite");
-                }                
+                }
 
             }
 
@@ -335,31 +335,52 @@
         public void DuplicateCustomTabDiscovered(string id)
         {
             QuickLogger.Warning($"Duplicate entry for {CustomCraftingTabList.ListKey} '{id}' from {this.Origin} was already added by another working file. Kept first one. Discarded duplicate.");
-            this.UniqueCustomTabs.Remove(id);
+            if (this.UniqueCustomTabs.TryGetValue(id, out CfCustomCraftingTab tab))
+            {
+                tab.PassedSecondValidation = false;
+                this.PassedSecondValidation = false;
+            }
         }
 
         public void DuplicateMovedRecipeDiscovered(string id)
         {
             QuickLogger.Warning($"Duplicate entry for {MovedRecipeList.ListKey} '{id}' from {this.Origin} was already added by another working file. Kept first one. Discarded duplicate.");
-            this.UniqueMovedRecipes.Remove(id);
+            if (this.UniqueMovedRecipes.TryGetValue(id, out CfMovedRecipe moved))
+            {
+                moved.PassedSecondValidation = false;
+                this.PassedSecondValidation = false;
+            }
         }
 
         public void DuplicateAddedRecipeDiscovered(string id)
         {
             QuickLogger.Warning($"Duplicate entry for {AddedRecipeList.ListKey} '{id}' from {this.Origin} was already added by another working file. Kept first one. Discarded duplicate.");
-            this.UniqueAddedRecipes.Remove(id);
+            if (this.UniqueAddedRecipes.TryGetValue(id, out CfAddedRecipe added))
+            {
+                added.PassedSecondValidation = false;
+                this.PassedSecondValidation = false;
+            }
         }
 
         public void DuplicateAliasRecipesDiscovered(string id)
         {
             QuickLogger.Warning($"Duplicate entry for {AliasRecipeList.ListKey} '{id}' from {this.Origin} was already added by another working file. Kept first one. Discarded duplicate.");
-            this.UniqueAliasRecipes.Remove(id);
+            if (this.UniqueAliasRecipes.TryGetValue(id, out CfAliasRecipe alias))
+            {
+                alias.PassedSecondValidation = false;
+                this.PassedSecondValidation = false;
+            }
         }
 
         public void DuplicateCustomFoodsDiscovered(string id)
         {
             QuickLogger.Warning($"Duplicate entry for {CustomFoodList.ListKey} '{id}' from {this.Origin} was already added by another working file. Kept first one. Discarded duplicate.");
             this.UniqueCustomFoods.Remove(id);
+            if (this.UniqueCustomFoods.TryGetValue(id, out CfCustomFood food))
+            {
+                food.PassedSecondValidation = false;
+                this.PassedSecondValidation = false;
+            }
         }
 
         internal override EmProperty Copy()

--- a/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
@@ -339,6 +339,7 @@
             {
                 tab.PassedSecondValidation = false;
                 this.PassedSecondValidation = false;
+                this.UniqueCustomTabs.Remove(id);
             }
         }
 
@@ -349,6 +350,7 @@
             {
                 moved.PassedSecondValidation = false;
                 this.PassedSecondValidation = false;
+                this.UniqueMovedRecipes.Remove(id);
             }
         }
 
@@ -359,6 +361,7 @@
             {
                 added.PassedSecondValidation = false;
                 this.PassedSecondValidation = false;
+                this.UniqueAddedRecipes.Remove(id);
             }
         }
 
@@ -369,6 +372,7 @@
             {
                 alias.PassedSecondValidation = false;
                 this.PassedSecondValidation = false;
+                this.UniqueAliasRecipes.Remove(id);
             }
         }
 
@@ -380,6 +384,7 @@
             {
                 food.PassedSecondValidation = false;
                 this.PassedSecondValidation = false;
+                this.UniqueCustomFoods.Remove(id);
             }
         }
 

--- a/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFabricator.cs
@@ -146,7 +146,7 @@
         public ICollection<string> AliasRecipesIDs => this.UniqueAliasRecipes.Keys;
         public ICollection<string> CustomFoodIDs => this.UniqueCustomFoods.Keys;
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
             return ItemIDisUnique() & InnerItemsAreValid() & FunctionalItemIsValid() & ValidFabricatorValues() & ValidateInternalEntries();
         }
@@ -249,7 +249,7 @@
             {
                 entry.ParentFabricator = this;
                 entry.Origin = this.Origin;
-                if (!entry.PassesPreValidation())
+                if (!entry.PassesPreValidation(entry.Origin))
                     continue;
 
                 if (uniqueEntries.ContainsKey(entry.ID))

--- a/CustomCraftSML/Serialization/Entries/CustomFood.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFood.cs
@@ -214,9 +214,9 @@
             return new CustomFood(this.Key, this.CopyDefinitions);
         }
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
-            return base.PassesPreValidation() & ValidateCustomFoodValues();
+            return base.PassesPreValidation(originFile) & ValidateCustomFoodValues();
         }
 
         private bool ValidateCustomFoodValues()

--- a/CustomCraftSML/Serialization/Entries/CustomFragmentCount.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFragmentCount.cs
@@ -42,6 +42,8 @@
 
         public OriginFile Origin { get; set; }
 
+        public bool PassedSecondValidation => true;
+
         internal CustomFragmentCount(string itemID, int fragmentsToScan) : this()
         {
             this.ItemID = itemID;

--- a/CustomCraftSML/Serialization/Entries/CustomSize.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomSize.cs
@@ -64,6 +64,8 @@
 
         public OriginFile Origin { get; set; }
 
+        public bool PassedSecondValidation => true;
+
         public CustomSize() : this("CustomSize", SizeProperties)
         {
         }

--- a/CustomCraftSML/Serialization/Entries/CustomSize.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomSize.cs
@@ -79,9 +79,9 @@
             return new CustomSize(this.Key, this.CopyDefinitions);
         }
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
-            return base.PassesPreValidation() & ValidateSizes();
+            return base.PassesPreValidation(originFile) & ValidateSizes();
         }
 
         private bool ValidateSizes()

--- a/CustomCraftSML/Serialization/Entries/ModifiedRecipe.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedRecipe.cs
@@ -149,9 +149,9 @@
             return new ModifiedRecipe(this.Key, this.CopyDefinitions);
         }
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
-            return base.PassesPreValidation() & InnerItemsAreValid();
+            return base.PassesPreValidation(originFile) & InnerItemsAreValid();
         }
 
         protected bool InnerItemsAreValid()
@@ -233,7 +233,7 @@
 
             foreach (EmIngredient ingredient in this.Ingredients)
             {
-                if (ingredient.PassesPreValidation())
+                if (ingredient.PassesPreValidation(this.Origin))
                     this.SMLHelperIngredients.Add(ingredient.ToSMLHelperIngredient());
                 else
                     ingredientsValid = false;

--- a/CustomCraftSML/Serialization/Entries/ModifiedRecipe.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedRecipe.cs
@@ -99,6 +99,8 @@
 
         public OriginFile Origin { get; set; }
 
+        public bool PassedSecondValidation { get; internal set; } = true;
+
         internal ModifiedRecipe(TechType origTechType) : this()
         {
             ITechData origRecipe = CraftData.Get(origTechType);

--- a/CustomCraftSML/Serialization/Entries/MovedRecipe.cs
+++ b/CustomCraftSML/Serialization/Entries/MovedRecipe.cs
@@ -103,9 +103,9 @@
             return new MovedRecipe(this.Key, this.CopyDefinitions);
         }
 
-        public override bool PassesPreValidation()
+        public override bool PassesPreValidation(OriginFile originFile)
         {
-            return base.PassesPreValidation() & IsValidState();
+            return base.PassesPreValidation(originFile) & IsValidState();
         }
 
         private bool IsValidState()

--- a/CustomCraftSML/Serialization/Entries/MovedRecipe.cs
+++ b/CustomCraftSML/Serialization/Entries/MovedRecipe.cs
@@ -60,6 +60,8 @@
 
         public OriginFile Origin { get; set; }
 
+        public bool PassedSecondValidation { get; set; } = true;
+
         public MovedRecipe() : this(TypeName, MovedRecipeProperties)
         {
         }

--- a/CustomCraftSML/Serialization/ParsingPackage.cs
+++ b/CustomCraftSML/Serialization/ParsingPackage.cs
@@ -74,8 +74,14 @@
             int successCount = 0;
             foreach (CustomCraftEntry item in this.UniqueEntries.Values)
             {
-                if (item.SendToSMLHelper())
+                if (item.PassedSecondValidation)
+                {
+                    QuickLogger.Warning($"Entry for '{item.ID}' from file '{item.Origin}' failed secondary checks for duplicate IDs. It will not be patched.");
+                }
+                else if (item.SendToSMLHelper())
+                {
                     successCount++;
+                }
             }
 
             if (this.UniqueEntries.Count > 0)

--- a/CustomCraftSML/Serialization/ParsingPackage.cs
+++ b/CustomCraftSML/Serialization/ParsingPackage.cs
@@ -51,7 +51,7 @@
             //      temp structure, but change the permanent one in the case of duplicates
             foreach (CustomCraftEntry item in this.ParsedEntries)
             {
-                if (!item.PassesPreValidation())
+                if (!item.PassesPreValidation(item.Origin))
                     continue;
 
                 if (this.UniqueEntries.ContainsKey(item.ID))

--- a/CustomCraftSML/Serialization/ParsingPackage.cs
+++ b/CustomCraftSML/Serialization/ParsingPackage.cs
@@ -74,7 +74,7 @@
             int successCount = 0;
             foreach (CustomCraftEntry item in this.UniqueEntries.Values)
             {
-                if (item.PassedSecondValidation)
+                if (!item.PassedSecondValidation)
                 {
                     QuickLogger.Warning($"Entry for '{item.ID}' from file '{item.Origin}' failed secondary checks for duplicate IDs. It will not be patched.");
                 }

--- a/CustomCraftSML/mod.json
+++ b/CustomCraftSML/mod.json
@@ -2,7 +2,7 @@
   "Id": "CustomCraft2SML",
   "DisplayName": "CustomCraft2SML",
   "Author": "PrimeSonic & contributors",
-  "Version": "1.8.3",
+  "Version": "1.8.4",
   "Enable": true,
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "Subnautica",

--- a/CustomCraftSMLTests/CustomCraftSMLTests.csproj
+++ b/CustomCraftSMLTests/CustomCraftSMLTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -76,16 +76,13 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="SMLHelper, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -117,9 +114,6 @@
     <Compile Include="VModFabricatorFiles.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\CustomCraftSML\CustomCraft2SML.csproj">
       <Project>{656A031A-0BAE-4633-89F7-0F3464D247E2}</Project>
       <Name>CustomCraft2SML</Name>
@@ -132,17 +126,19 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/CustomCraftSMLTests/packages.config
+++ b/CustomCraftSMLTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net471" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net471" />
-  <package id="NUnit" version="3.10.1" targetFramework="net471" />
-  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net471" />
+  <package id="MSTest.TestAdapter" version="2.1.0" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="2.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.12.0" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- Fixed exception during duplicate checks of custom fabricator internals
- Added additional debug logging
- `OriginFile` now displayed on failed uniqueness checks
- Secondary uniqueness checks caught early, preventing patching errors

[CC2_184_v4.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/4366397/CC2_184_v4.zip)


