### PR TITLE
CyNukeUpgrades v4.2

### DIFF
--- a/CyclopsNuclearUpgrades/CyclopsNuclearUpgrades.csproj
+++ b/CyclopsNuclearUpgrades/CyclopsNuclearUpgrades.csproj
@@ -47,6 +47,7 @@
     </Reference>
     <Reference Include="QModInstaller">
       <HintPath>..\DependenciesSubnautica\QModInstaller.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SMLHelper, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -83,6 +84,7 @@
     <ProjectReference Include="..\MoreCyclopsUpgrades\MoreCyclopsUpgrades.csproj">
       <Project>{fc87af94-413d-482e-ab0d-501e120e6e2d}</Project>
       <Name>MoreCyclopsUpgrades</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/CyclopsNuclearUpgrades/CyclopsNuclearUpgrades.csproj
+++ b/CyclopsNuclearUpgrades/CyclopsNuclearUpgrades.csproj
@@ -45,6 +45,9 @@
       <HintPath>..\DependenciesSubnautica\Assembly-CSharp_publicized.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="QModInstaller">
+      <HintPath>..\DependenciesSubnautica\QModInstaller.dll</HintPath>
+    </Reference>
     <Reference Include="SMLHelper, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DependenciesSubnautica\SMLHelper.dll</HintPath>
@@ -69,6 +72,7 @@
     <Compile Include="Items\CyclopsNuclearModule.cs" />
     <Compile Include="Items\DepletedNuclearModule.cs" />
     <Compile Include="Items\NuclearFabricator.cs" />
+    <Compile Include="Management\BatteryDetails.cs" />
     <Compile Include="Management\NuclearChargeHandler.cs" />
     <Compile Include="Management\NuclearIconOverlay.cs" />
     <Compile Include="Management\NuclearUpgradeHandler.cs" />

--- a/CyclopsNuclearUpgrades/Items/CyclopsNuclearModule.cs
+++ b/CyclopsNuclearUpgrades/Items/CyclopsNuclearModule.cs
@@ -12,6 +12,12 @@
         private const string MaxNuclearReachedKey = "MaxNuclearMsg";
         internal static string MaxNuclearReachedMsg => Language.main.Get(MaxNuclearReachedKey);
 
+        private const string OverheatKey = "CyNukOverheat";
+        internal static string OverheatMsg => Language.main.Get(OverheatKey);
+
+        private const string DepletedEventKey = "CyNukeDepleted";
+        internal static string DepletedEventMsg => Language.main.Get(DepletedEventKey);
+
         public override CraftTree.Type FabricatorType { get; } = CraftTree.Type.Workbench;
 
         public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
@@ -31,6 +37,8 @@
             OnFinishedPatching += () =>
             {
                 LanguageHandler.SetLanguageLine(MaxNuclearReachedKey, "Max number of nuclear chargers.");
+                LanguageHandler.SetLanguageLine(OverheatKey, "SHUTDOWN");
+                LanguageHandler.SetLanguageLine(DepletedEventKey, "Nuclear Reactor Module depleted");
             };
         }
 

--- a/CyclopsNuclearUpgrades/Items/CyclopsNuclearModule.cs
+++ b/CyclopsNuclearUpgrades/Items/CyclopsNuclearModule.cs
@@ -9,13 +9,18 @@
     {
         internal const float NuclearEnergyPotential = 6000f; // Less than the normal 20k for balance
 
-        public override CraftTree.Type FabricatorType { get; } = CraftTree.Type.Workbench;
-        public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
-        public override TechType RequiredForUnlock { get; } = TechType.BaseNuclearReactor;
-        public override string[] StepsToFabricatorTab { get; } = new[] { "CyclopsMenu" };
-
         private const string MaxNuclearReachedKey = "MaxNuclearMsg";
         internal static string MaxNuclearReachedMsg => Language.main.Get(MaxNuclearReachedKey);
+
+        public override CraftTree.Type FabricatorType { get; } = CraftTree.Type.Workbench;
+
+        public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
+
+        public override TechType RequiredForUnlock { get; } = TechType.BaseNuclearReactor;
+
+        public override string[] StepsToFabricatorTab { get; } = new[] { "CyclopsMenu" };
+
+        public override float CraftingTime => 12f;
 
         internal CyclopsNuclearModule()
             : base("CyclopsNuclearModule",
@@ -25,7 +30,6 @@
         {
             OnFinishedPatching += () =>
             {
-                CraftDataHandler.SetCraftingTime(this.TechType, 12f);
                 LanguageHandler.SetLanguageLine(MaxNuclearReachedKey, "Max number of nuclear chargers.");
             };
         }

--- a/CyclopsNuclearUpgrades/Items/DepletedNuclearModule.cs
+++ b/CyclopsNuclearUpgrades/Items/DepletedNuclearModule.cs
@@ -1,18 +1,15 @@
 ﻿namespace CyclopsNuclearUpgrades
 {
-    using CyclopsNuclearUpgrades.Management;
-    using MoreCyclopsUpgrades.API.Charging;
-    using MoreCyclopsUpgrades.API.Upgrades;
     using SMLHelper.V2.Assets;
     using SMLHelper.V2.Handlers;
     using UnityEngine;
 
-    internal class DepletedNuclearModule : Spawnable, INuclearModuleDepleter, IUpgradeHandlerCreator, ICyclopsChargerCreator
+    internal class DepletedNuclearModule : Spawnable
     {
         private readonly CyclopsNuclearModule nuclearModule;
 
         private const string DepletedEventKey = "CyNukeDepleted";
-        private static string DepletedEventMsg => Language.main.Get(DepletedEventKey);
+        internal static string DepletedEventMsg => Language.main.Get(DepletedEventKey);
 
         public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
 
@@ -38,24 +35,6 @@
         public override GameObject GetGameObject()
         {
             return GameObject.Instantiate(CraftData.GetPrefabForTechType(TechType.DepletedReactorRod));
-        }
-
-        public void DepleteNuclearModule(Equipment modules, string slotName)
-        {
-            InventoryItem inventoryItem = modules.RemoveItem(slotName, true, false);
-            GameObject.Destroy(inventoryItem.item.gameObject);
-            modules.AddItem(slotName, CyclopsUpgrade.SpawnCyclopsModule(this.TechType), true);
-            ErrorMessage.AddMessage(DepletedEventMsg);
-        }
-
-        public UpgradeHandler CreateUpgradeHandler(SubRoot cyclops)
-        {
-            return new NuclearUpgradeHandler(nuclearModule.TechType, this, cyclops);
-        }
-
-        public CyclopsCharger CreateCyclopsCharger(SubRoot cyclops)
-        {
-            return new NuclearChargeHandler(cyclops, nuclearModule.TechType);
         }
     }
 }

--- a/CyclopsNuclearUpgrades/Items/DepletedNuclearModule.cs
+++ b/CyclopsNuclearUpgrades/Items/DepletedNuclearModule.cs
@@ -1,15 +1,11 @@
 ﻿namespace CyclopsNuclearUpgrades
 {
     using SMLHelper.V2.Assets;
-    using SMLHelper.V2.Handlers;
     using UnityEngine;
 
     internal class DepletedNuclearModule : Spawnable
     {
         private readonly CyclopsNuclearModule nuclearModule;
-
-        private const string DepletedEventKey = "CyNukeDepleted";
-        internal static string DepletedEventMsg => Language.main.Get(DepletedEventKey);
 
         public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
 
@@ -24,11 +20,6 @@
             {
                 if (!nuclearModule.IsPatched)
                     nuclearModule.Patch();
-            };
-
-            OnFinishedPatching += () =>
-            {
-                LanguageHandler.SetLanguageLine(DepletedEventKey, "Nuclear Reactor Module depleted");
             };
         }
 

--- a/CyclopsNuclearUpgrades/Items/NuclearFabricator.cs
+++ b/CyclopsNuclearUpgrades/Items/NuclearFabricator.cs
@@ -15,8 +15,6 @@
 
         public override TechCategory CategoryForPDA => TechCategory.InteriorModule;
 
-        public override string AssetsFolder => "CyclopsNuclearUpgrades/Assets";
-
         public override TechType RequiredForUnlock => TechType.BaseNuclearReactor;
 
         public override Models Model => Models.Custom; // Using Custom so the texture can be altered
@@ -35,10 +33,7 @@
             {
                 if (!nuclearModule.IsPatched)
                     nuclearModule.Patch();
-            };
 
-            OnFinishedPatching += () =>
-            {
                 // Load the custom texture
                 string executingLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string folderPath = Path.Combine(executingLocation, "Assets");
@@ -49,12 +44,6 @@
                 string spriteLocation = Path.Combine(folderPath, "NuclearFabricator.png");
                 sprite = ImageUtils.LoadSpriteFromFile(spriteLocation) ?? SpriteManager.Get(TechType.Fabricator);
             };
-
-            AddCraftNode(TechType.ReactorRod);
-            AddCraftNode(nuclearModule.TechType);
-            AddCraftNode("RReactorRodDUMMY"); // Optional - Refill nuclear reactor rod
-            AddCraftNode("CyNukeUpgrade1"); // Optional - Cyclops Nuclear Reactor Enhancer Mk1
-            AddCraftNode("CyNukeUpgrade2"); // Optional - Cyclops Nuclear Reactor Enhancer Mk2
         }
 
         protected override GameObject GetCustomCrafterPreFab()

--- a/CyclopsNuclearUpgrades/Items/NuclearFabricator.cs
+++ b/CyclopsNuclearUpgrades/Items/NuclearFabricator.cs
@@ -1,26 +1,31 @@
 ﻿namespace CyclopsNuclearUpgrades
 {
+    using System.IO;
+    using System.Reflection;
     using SMLHelper.V2.Assets;
     using SMLHelper.V2.Crafting;
-    using SMLHelper.V2.Handlers;
     using SMLHelper.V2.Utility;
     using UnityEngine;
 
-    internal class NuclearFabricator : Buildable
+    internal class NuclearFabricator : CustomFabricator
     {
-        private const string NameID = "NuclearFabricator";
         private readonly CyclopsNuclearModule nuclearModule;
 
-        public CraftTree.Type TreeTypeID { get; private set; }
-        public override TechGroup GroupForPDA { get; } = TechGroup.InteriorModules;
-        public override TechCategory CategoryForPDA { get; } = TechCategory.InteriorModule;
-        public override string AssetsFolder { get; } = "CyclopsNuclearUpgrades/Assets";
-        public override TechType RequiredForUnlock { get; } = TechType.BaseNuclearReactor;
+        public override TechGroup GroupForPDA => TechGroup.InteriorModules;
 
-        private const string HandOverKey = "UseNukFabricator";
+        public override TechCategory CategoryForPDA => TechCategory.InteriorModule;
+
+        public override string AssetsFolder => "CyclopsNuclearUpgrades/Assets";
+
+        public override TechType RequiredForUnlock => TechType.BaseNuclearReactor;
+
+        public override Models Model => Models.Custom; // Using Custom so the texture can be altered
+
+        private static Texture2D customTexture;
+        private static Atlas.Sprite sprite;
 
         internal NuclearFabricator(CyclopsNuclearModule module)
-            : base(NameID,
+            : base("NuclearFabricator",
                    "Nuclear Fabricator",
                    "A specialized fabricator for safe handling of radioactive energy sources.")
         {
@@ -34,86 +39,47 @@
 
             OnFinishedPatching += () =>
             {
-                LanguageHandler.SetLanguageLine(HandOverKey, "Use Nuclear Fabricator");
-                this.TreeTypeID = CreateCustomTree();
+                // Load the custom texture
+                string executingLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string folderPath = Path.Combine(executingLocation, "Assets");
+
+                string textureLocation = Path.Combine(folderPath, "NuclearFabricatorT.png");
+                customTexture = ImageUtils.LoadTextureFromFile(textureLocation);
+
+                string spriteLocation = Path.Combine(folderPath, "NuclearFabricator.png");
+                sprite = ImageUtils.LoadSpriteFromFile(spriteLocation) ?? SpriteManager.Get(TechType.Fabricator);
             };
+
+            AddCraftNode(TechType.ReactorRod);
+            AddCraftNode(nuclearModule.TechType);
+            AddCraftNode("RReactorRodDUMMY"); // Optional - Refill nuclear reactor rod
+            AddCraftNode("CyNukeUpgrade1"); // Optional - Cyclops Nuclear Reactor Enhancer Mk1
+            AddCraftNode("CyNukeUpgrade2"); // Optional - Cyclops Nuclear Reactor Enhancer Mk2
         }
 
-        private CraftTree.Type CreateCustomTree()
-        {
-            ModCraftTreeRoot rootNode = CraftTreeHandler.CreateCustomCraftTreeAndType(NameID, out CraftTree.Type craftType);
-
-            rootNode.AddCraftingNode(TechType.ReactorRod);
-            rootNode.AddCraftingNode(nuclearModule.TechType);
-            rootNode.AddModdedCraftingNode("RReactorRodDUMMY"); // Refill nuclear reactor rod
-            rootNode.AddModdedCraftingNode("CyNukeUpgrade1"); // Cyclops Nuclear Reactor Enhancer Mk1
-            rootNode.AddModdedCraftingNode("CyNukeUpgrade2"); // Cyclops Nuclear Reactor Enhancer Mk2
-
-            return craftType;
-        }
-
-        public override GameObject GetGameObject()
+        protected override GameObject GetCustomCrafterPreFab()
         {
             // Instantiate Fabricator object
-            var prefab = GameObject.Instantiate(CraftData.GetPrefabForTechType(TechType.Fabricator));
-
-            // Update prefab name
-            prefab.name = NameID;
-
-            // Add prefab ID
-            PrefabIdentifier prefabId = prefab.GetComponent<PrefabIdentifier>();
-            if (prefabId != null)
-            {
-                prefabId.ClassId = NameID;
-                prefabId.name = this.FriendlyName;
-            }
-
-            // Add tech tag
-            TechTag techTag = prefab.GetComponent<TechTag>();
-            if (techTag != null)
-            {
-                techTag.type = this.TechType;
-            }
-
-            // Update sky applier
-            SkyApplier skyApplier = prefab.GetComponent<SkyApplier>();
-            skyApplier.renderers = prefab.GetComponentsInChildren<Renderer>();
-            skyApplier.anchorSky = Skies.Auto;
-
-            // Associate custom craft tree to the fabricator
-            GhostCrafter fabricator = prefab.GetComponent<Fabricator>();
-            fabricator.craftTree = this.TreeTypeID;
-            fabricator.handOverText = Language.main.Get(HandOverKey);
-
-            // Modify existing constructable - This is just a modified Fabricator which already had a Constructible component.
-            Constructable constructible = prefab.GetComponent<Constructable>();
-
-            constructible.allowedInBase = true;
-            constructible.allowedInSub = true;
-            constructible.allowedOutside = false;
-            constructible.allowedOnCeiling = false;
-            constructible.allowedOnGround = false;
-            constructible.allowedOnWall = true;
-            constructible.allowedOnConstructables = false;
-            constructible.controlModelState = true;
-            constructible.rotationEnabled = false;
-            constructible.techType = this.TechType; // This was necessary to correctly associate the recipe at building time
+            var gObj = GameObject.Instantiate(CraftData.GetPrefabForTechType(TechType.Fabricator));
 
             // Set the custom texture
-            Texture2D customTexture = ImageUtils.LoadTextureFromFile(@"./QMods/CyclopsNuclearUpgrades/Assets/NuclearFabricatorT.png");
-            SkinnedMeshRenderer skinnedMeshRenderer = prefab.GetComponentInChildren<SkinnedMeshRenderer>();
-            skinnedMeshRenderer.material.mainTexture = customTexture;
+            if (customTexture != null)
+            {
+                SkinnedMeshRenderer skinnedMeshRenderer = gObj.GetComponentInChildren<SkinnedMeshRenderer>();
+                skinnedMeshRenderer.material.mainTexture = customTexture;
+            }
 
-            // Associate power relay
-            var powerRelay = new PowerRelay();
+            // Change size
+            Vector3 scale = gObj.transform.localScale;
+            const float factor = 0.90f;
+            gObj.transform.localScale = new Vector3(scale.x * factor, scale.y * factor, scale.z * factor);
 
-            // This is actually a dirty hack
-            // The problem is that the parent SubRoot isn't correctly associated at this time.
-            // The power relay should be getting set in the GhostCrafter Start() method.
-            // But the parent components are coming up null.
-            fabricator.powerRelay = powerRelay;
+            return gObj;
+        }
 
-            return prefab;
+        protected override Atlas.Sprite GetItemSprite()
+        {
+            return sprite;
         }
 
         protected override TechData GetBlueprintRecipe()

--- a/CyclopsNuclearUpgrades/Management/BatteryDetails.cs
+++ b/CyclopsNuclearUpgrades/Management/BatteryDetails.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// A simple class for <see cref="Equipment"/> modules that contain a <see cref="Battery"/> component
     /// </summary>
-    internal class BatteryDetails
+    internal struct BatteryDetails
     {
         public readonly Equipment ParentEquipment;
         public readonly string SlotName;

--- a/CyclopsNuclearUpgrades/Management/BatteryDetails.cs
+++ b/CyclopsNuclearUpgrades/Management/BatteryDetails.cs
@@ -1,0 +1,22 @@
+﻿namespace CyclopsNuclearUpgrades.Management
+{
+    /// <summary>
+    /// A simple class for <see cref="Equipment"/> modules that contain a <see cref="Battery"/> component
+    /// </summary>
+    internal class BatteryDetails
+    {
+        public readonly Equipment ParentEquipment;
+        public readonly string SlotName;
+        public readonly Battery BatteryRef;
+
+        public bool IsFull => BatteryRef._charge == BatteryRef._capacity;
+        public bool HasCharge => BatteryRef._charge == 0f;
+
+        public BatteryDetails(Equipment parentEquipment, string slotName, Battery batteryRef)
+        {
+            ParentEquipment = parentEquipment;
+            SlotName = slotName;
+            BatteryRef = batteryRef;
+        }
+    }
+}

--- a/CyclopsNuclearUpgrades/Management/NuclearChargeHandler.cs
+++ b/CyclopsNuclearUpgrades/Management/NuclearChargeHandler.cs
@@ -19,7 +19,7 @@
         private const float MaxNuclearChargeRate = 20.0f;
         private const float MinNuclearChargeRate = 0.12f;
         private const float CooldownRate = 5.0f;
-        private const float HeatModifier = 2.0f;
+        private const float HeatModifier = 2.05f;
         internal const float MaxHeatLoad = 300f;
 
         private readonly TechType nuclearModuleID;

--- a/CyclopsNuclearUpgrades/Management/NuclearIconOverlay.cs
+++ b/CyclopsNuclearUpgrades/Management/NuclearIconOverlay.cs
@@ -7,14 +7,12 @@
 
     internal class NuclearIconOverlay : IconOverlay
     {
-        private readonly NuclearUpgradeHandler upgradeHandler;
         private readonly NuclearChargeHandler chargeHandler;
         private readonly Battery battery;
 
         public NuclearIconOverlay(uGUI_ItemIcon icon, InventoryItem upgradeModule)
             : base(icon, upgradeModule)
         {
-            upgradeHandler = MCUServices.Find.CyclopsUpgradeHandler<NuclearUpgradeHandler>(base.Cyclops, base.TechType);
             chargeHandler = MCUServices.Find.CyclopsCharger<NuclearChargeHandler>(base.Cyclops);
             battery = base.Item.item.GetComponent<Battery>();
         }
@@ -25,7 +23,7 @@
 
             if (chargeHandler.IsOverheated)
             {
-                base.UpperText.TextString = "SHUTDOWN";
+                base.UpperText.TextString = CyclopsNuclearModule.OverheatMsg;
                 base.UpperText.FontSize = 14;
             }
             else

--- a/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
+++ b/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.1.1.0")]
-[assembly: AssemblyFileVersion("4.1.1.0")]
+[assembly: AssemblyVersion("4.2.0.0")]
+[assembly: AssemblyFileVersion("4.2.0.0")]

--- a/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
+++ b/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.0.0")]
-[assembly: AssemblyFileVersion("4.2.0.0")]
+[assembly: AssemblyVersion("4.3.0.0")]
+[assembly: AssemblyFileVersion("4.3.0.0")]

--- a/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
+++ b/CyclopsNuclearUpgrades/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.3.0.0")]
-[assembly: AssemblyFileVersion("4.3.0.0")]
+[assembly: AssemblyVersion("4.2.0.0")]
+[assembly: AssemblyFileVersion("4.2.0.0")]

--- a/CyclopsNuclearUpgrades/QPatch.cs
+++ b/CyclopsNuclearUpgrades/QPatch.cs
@@ -15,10 +15,17 @@
 
             var nuclearModule = new CyclopsNuclearModule();
             var depletedModule = new DepletedNuclearModule(nuclearModule);
-            var nuclearFabricator = new NuclearFabricator(nuclearModule);
 
             nuclearModule.Patch();
             depletedModule.Patch();
+
+            var nuclearFabricator = new NuclearFabricator(nuclearModule);
+            nuclearFabricator.AddCraftNode(TechType.ReactorRod);
+            nuclearFabricator.AddCraftNode(nuclearModule.TechType);
+            nuclearFabricator.AddCraftNode("RReactorRodDUMMY"); // Optional - Refill nuclear reactor rod (old)
+            nuclearFabricator.AddCraftNode("ReplenishReactorRod"); // Optional - Refill nuclear reactor rod (new)
+            nuclearFabricator.AddCraftNode("CyNukeUpgrade1"); // Optional - Cyclops Nuclear Reactor Enhancer Mk1
+            nuclearFabricator.AddCraftNode("CyNukeUpgrade2"); // Optional - Cyclops Nuclear Reactor Enhancer Mk2
             nuclearFabricator.Patch();
 
             MCUServices.Register.CyclopsUpgradeHandler((SubRoot cyclops) =>

--- a/CyclopsNuclearUpgrades/QPatch.cs
+++ b/CyclopsNuclearUpgrades/QPatch.cs
@@ -8,11 +8,10 @@
     [QModCore]
     public static class QPatch
     {
-
         [QModPatch]
         public static void Patch()
         {
-            QuickLogger.Info("Started patching v" + QuickLogger.GetAssemblyVersion());
+            MCUServices.Logger.Info("Started patching v" + QuickLogger.GetAssemblyVersion());
 
             var nuclearModule = new CyclopsNuclearModule();
             var depletedModule = new DepletedNuclearModule(nuclearModule);
@@ -26,16 +25,18 @@
             {
                 return new NuclearUpgradeHandler(nuclearModule.TechType, cyclops);
             });
+
             MCUServices.Register.CyclopsCharger<NuclearChargeHandler>((SubRoot cyclops) =>
             {
                 return new NuclearChargeHandler(cyclops, nuclearModule.TechType);
             });
+
             MCUServices.Register.PdaIconOverlay(nuclearModule.TechType, (uGUI_ItemIcon icon, InventoryItem upgradeModule) =>
             {
                 return new NuclearIconOverlay(icon, upgradeModule);
             });
 
-            QuickLogger.Info("Finished patching");
+            MCUServices.Logger.Info("Finished patching");
         }
     }
 }

--- a/CyclopsNuclearUpgrades/QPatch.cs
+++ b/CyclopsNuclearUpgrades/QPatch.cs
@@ -1,36 +1,41 @@
 ﻿namespace CyclopsNuclearUpgrades
 {
-    using System;
     using Common;
     using CyclopsNuclearUpgrades.Management;
     using MoreCyclopsUpgrades.API;
+    using QModManager.API.ModLoading;
 
+    [QModCore]
     public static class QPatch
     {
 
+        [QModPatch]
         public static void Patch()
         {
-            try
-            {
-                var nuclearModule = new CyclopsNuclearModule();
-                var depletedModule = new DepletedNuclearModule(nuclearModule);
-                var nuclearFabricator = new NuclearFabricator(nuclearModule);
+            QuickLogger.Info("Started patching v" + QuickLogger.GetAssemblyVersion());
 
-                nuclearModule.Patch();
-                depletedModule.Patch();
-                nuclearFabricator.Patch();
+            var nuclearModule = new CyclopsNuclearModule();
+            var depletedModule = new DepletedNuclearModule(nuclearModule);
+            var nuclearFabricator = new NuclearFabricator(nuclearModule);
 
-                MCUServices.Register.CyclopsUpgradeHandler(depletedModule);
-                MCUServices.Register.CyclopsCharger<NuclearChargeHandler>(depletedModule);
-                MCUServices.Register.PdaIconOverlay(nuclearModule.TechType, (uGUI_ItemIcon icon, InventoryItem upgradeModule) =>
-                {
-                    return new NuclearIconOverlay(icon, upgradeModule);
-                });
-            }
-            catch(Exception ex)
+            nuclearModule.Patch();
+            depletedModule.Patch();
+            nuclearFabricator.Patch();
+
+            MCUServices.Register.CyclopsUpgradeHandler((SubRoot cyclops) =>
             {
-                QuickLogger.Error(ex);
-            }
+                return new NuclearUpgradeHandler(nuclearModule.TechType, cyclops);
+            });
+            MCUServices.Register.CyclopsCharger<NuclearChargeHandler>((SubRoot cyclops) =>
+            {
+                return new NuclearChargeHandler(cyclops, nuclearModule.TechType);
+            });
+            MCUServices.Register.PdaIconOverlay(nuclearModule.TechType, (uGUI_ItemIcon icon, InventoryItem upgradeModule) =>
+            {
+                return new NuclearIconOverlay(icon, upgradeModule);
+            });
+
+            QuickLogger.Info("Finished patching");
         }
     }
 }

--- a/CyclopsNuclearUpgrades/mod.json
+++ b/CyclopsNuclearUpgrades/mod.json
@@ -1,12 +1,10 @@
 {
   "Id": "CyclopsNuclearUpgrades",
-  "DisplayName": "CyclopsNuclearUpgrades",
+  "DisplayName": "Cyclops Nuclear Upgrades",
   "Author": "PrimeSonic",
-  "Version": "4.1.1",
+  "Version": "4.2.0",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CyclopsNuclearUpgrades.dll",
-  "Dependencies": [ "SMLHelper", "MoreCyclopsUpgrades" ],
-  "LoadBefore": [ "MoreCyclopsUpgrades" ],
-  "EntryMethod": "CyclopsNuclearUpgrades.QPatch.Patch"
+  "Dependencies": [ "MoreCyclopsUpgrades" ]
 }

--- a/Utilities/QuickLogger.cs
+++ b/Utilities/QuickLogger.cs
@@ -54,6 +54,9 @@
                 ErrorMessage.AddWarning(msg);
         }
 
+        /// <summary>
+        /// Creates the version string in format "#.#.#" or "#.#.# rev:#"
+        /// </summary>
         public static string GetAssemblyVersion()
         {
             Version version = ModName.Version;


### PR DESCRIPTION
- Updated to QMM 3 style loading
- `NuclearFabricator` now inherits from SMLHelper's [CustomFabricator](https://github.com/SubnauticaModding/SMLHelper/blob/master/SMLHelper/Assets/CustomFabricator.cs)  
_can now serve as an example of how to make one_
- Now compatible with the new [Replenish Reactor Rods](https://www.nexusmods.com/subnautica/mods/230)
- Nuclear battery will heat up about 3% faster
- "SHUTDOWN" message in Icon Overlay now available to SMLHelper's [Language Line Overrides](https://github.com/SubnauticaModding/SMLHelper/wiki/For-Players---Customizing-in-game-text-for-any-mod-using-Language-Overrides)
- Max number of allowed nuclear modules per Sub increased to 4
- Code reorg
