### PR TITLE
CyclopsEngineUpgrades 4.2

### DIFF
--- a/CyclopsEngineUpgrades/Craftables/PowerUpgradeModuleMk3.cs
+++ b/CyclopsEngineUpgrades/Craftables/PowerUpgradeModuleMk3.cs
@@ -1,6 +1,5 @@
 ﻿namespace CyclopsEngineUpgrades.Craftables
 {
-    using CyclopsEngineUpgrades.Handlers;
     using MoreCyclopsUpgrades.API.Upgrades;
     using SMLHelper.V2.Crafting;
 
@@ -39,16 +38,6 @@
                     new Ingredient(TechType.Nickel, 1),
                 }
             };
-        }
-
-        internal EngineHandler CreateEngineHandler(SubRoot cyclops)
-        {
-            return new EngineHandler(previousTier, this, cyclops);
-        }
-
-        internal EngineOverlay CreateEngineOverlay(uGUI_ItemIcon icon, InventoryItem upgradeModule)
-        {
-            return new EngineOverlay(icon, upgradeModule);
         }
     }
 }

--- a/CyclopsEngineUpgrades/CyclopsEngineUpgrades.csproj
+++ b/CyclopsEngineUpgrades/CyclopsEngineUpgrades.csproj
@@ -40,6 +40,10 @@
       <HintPath>..\DependenciesSubnautica\Assembly-CSharp_publicized.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="QModInstaller">
+      <HintPath>..\DependenciesSubnautica\QModInstaller.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="SMLHelper, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DependenciesSubnautica\SMLHelper.dll</HintPath>
@@ -68,6 +72,7 @@
     <ProjectReference Include="..\MoreCyclopsUpgrades\MoreCyclopsUpgrades.csproj">
       <Project>{fc87af94-413d-482e-ab0d-501e120e6e2d}</Project>
       <Name>MoreCyclopsUpgrades</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/CyclopsEngineUpgrades/Handlers/EngineHandler.cs
+++ b/CyclopsEngineUpgrades/Handlers/EngineHandler.cs
@@ -13,12 +13,12 @@
 
         private static readonly float[] EnginePowerRatings = new float[PowerIndexCount]
         {
-            1f, 3f, 4f, 5f
+            1f, 3f, 4.5f, 6f
         };
 
         private static readonly float[] SilentRunningPowerCosts = new float[PowerIndexCount]
         {
-            5f, 4.5f, 4f, 3.5f
+            5f, 4.6f, 4.2f, 3.8f
         };
 
         private static readonly float[] SonarPowerCosts = new float[PowerIndexCount]
@@ -28,7 +28,7 @@
 
         private static readonly float[] ShieldPowerCosts = new float[PowerIndexCount]
         {
-            50f, 45f, 40f, 35f
+            50f, 46f, 42f, 38f
         };
 
         private int lastKnownPowerIndex = -1;

--- a/CyclopsEngineUpgrades/Handlers/EngineOverlay.cs
+++ b/CyclopsEngineUpgrades/Handlers/EngineOverlay.cs
@@ -1,14 +1,15 @@
 ﻿namespace CyclopsEngineUpgrades.Handlers
 {
-    using Common;
     using MoreCyclopsUpgrades.API;
     using MoreCyclopsUpgrades.API.PDA;
     using UnityEngine;
 
     internal class EngineOverlay : IconOverlay
     {
+        internal const string BonusKey = "CyEngBonusEff";
+        internal const string TotalKey = "CyEngTotalEff";
+
         private readonly EngineHandler engineHandler;
-        private readonly TechType techTypeInSlot;
         private readonly string tierString;
         private readonly string tierRating;
 
@@ -16,9 +17,11 @@
         {
             engineHandler = MCUServices.Find.CyclopsGroupUpgradeHandler<EngineHandler>(base.Cyclops, TechType.PowerUpgradeModule);
 
-            techTypeInSlot = upgradeModule.item.GetTechType();
+            TechType techTypeInSlot = upgradeModule.item.GetTechType();
+
             tierString = $"MK{engineHandler.TierValue(techTypeInSlot)}";
-            tierRating = $"[Bonus Efficiency]\n{Mathf.RoundToInt(engineHandler.EngineRating(techTypeInSlot) * 100f)}%";
+            tierRating = $"{Language.main.Get(BonusKey)}\n" +
+                         $"{Mathf.RoundToInt(engineHandler.EngineRating(techTypeInSlot) * 100f)}%";
         }
 
         public override void UpdateText()
@@ -32,8 +35,8 @@
             float currPowerRating = base.Cyclops.currPowerRating;
 
             base.LowerText.FontSize = 13;
-            base.LowerText.TextString = "[Total Efficiency]\n" +
-                                       $"{Mathf.RoundToInt(currPowerRating * 100f)}%";
+            base.LowerText.TextString = $"{Language.main.Get(TotalKey)}\n" +
+                                        $"{Mathf.RoundToInt(currPowerRating * 100f)}%";
 
             if (currPowerRating >= 1f)
             {

--- a/CyclopsEngineUpgrades/Properties/AssemblyInfo.cs
+++ b/CyclopsEngineUpgrades/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.1.1.0")]
-[assembly: AssemblyFileVersion("4.1.1.0")]
+[assembly: AssemblyVersion("4.2.0.0")]
+[assembly: AssemblyFileVersion("4.2.0.0")]

--- a/CyclopsEngineUpgrades/QPatch.cs
+++ b/CyclopsEngineUpgrades/QPatch.cs
@@ -2,13 +2,18 @@
 {
     using Common;
     using CyclopsEngineUpgrades.Craftables;
+    using CyclopsEngineUpgrades.Handlers;
     using MoreCyclopsUpgrades.API;
+    using QModManager.API.ModLoading;
+    using SMLHelper.V2.Handlers;
 
+    [QModCore]
     public static class QPatch
     {
+        [QModPatch]
         public static void Patch()
         {
-            QuickLogger.Info($"Started patching. Version {QuickLogger.GetAssemblyVersion()}");
+            MCUServices.Logger.Info($"Started patching. Version {QuickLogger.GetAssemblyVersion()}");
 
             var engineMk2Upgrade = new PowerUpgradeModuleMk2();
             var engineMk3Upgrade = new PowerUpgradeModuleMk3(engineMk2Upgrade);
@@ -16,12 +21,24 @@
             engineMk2Upgrade.Patch();
             engineMk3Upgrade.Patch();
 
-            MCUServices.Register.CyclopsUpgradeHandler(engineMk3Upgrade.CreateEngineHandler);
-            MCUServices.Register.PdaIconOverlay(TechType.PowerUpgradeModule, engineMk3Upgrade.CreateEngineOverlay);
-            MCUServices.Register.PdaIconOverlay(engineMk2Upgrade.TechType, engineMk3Upgrade.CreateEngineOverlay);
-            MCUServices.Register.PdaIconOverlay(engineMk3Upgrade.TechType, engineMk3Upgrade.CreateEngineOverlay);
+            LanguageHandler.SetLanguageLine(EngineOverlay.BonusKey, "[Bonus Efficiency]");
+            LanguageHandler.SetLanguageLine(EngineOverlay.TotalKey, "[Total Efficiency]");
 
-            QuickLogger.Info($"Finished patching.");
+            MCUServices.Register.CyclopsUpgradeHandler((SubRoot cyclops) =>
+            {
+                return new EngineHandler(engineMk2Upgrade, engineMk3Upgrade, cyclops);
+            });
+
+            MCUServices.Register.PdaIconOverlay(TechType.PowerUpgradeModule, CreateEngineOverlay);
+            MCUServices.Register.PdaIconOverlay(engineMk2Upgrade.TechType, CreateEngineOverlay);
+            MCUServices.Register.PdaIconOverlay(engineMk3Upgrade.TechType, CreateEngineOverlay);
+
+            MCUServices.Logger.Info($"Finished patching.");
+        }
+
+        internal static EngineOverlay CreateEngineOverlay(uGUI_ItemIcon icon, InventoryItem upgradeModule)
+        {
+            return new EngineOverlay(icon, upgradeModule);
         }
     }
 }

--- a/CyclopsEngineUpgrades/mod.json
+++ b/CyclopsEngineUpgrades/mod.json
@@ -2,11 +2,9 @@
   "Id": "CyclopsEngineUpgrades",
   "DisplayName": "CyclopsEngineUpgrades",
   "Author": "PrimeSonic",
-  "Version": "4.1.1",
+  "Version": "4.2.0",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CyclopsEngineUpgrades.dll",
-  "Dependencies": [ "SMLHelper", "MoreCyclopsUpgrades" ],
-  "LoadBefore": [ "MoreCyclopsUpgrades" ],
-  "EntryMethod": "CyclopsEngineUpgrades.QPatch.Patch"
+  "Dependencies": [ "MoreCyclopsUpgrades" ]
 }


### PR DESCRIPTION
- Enables language overrides to text from icon overlay
- Updated for QMM 3 loading
- Shield costs now reduced by 4 per tier instead of 5
- Silent running costs reduced by .4 per tier instead of .5
- Engine ratings for Mk2 is now 450%
- Engine ratings for Mk3 is now 600%
- code reorg