### PR TITLE
Cc2 originals path fix

### DIFF
--- a/CustomCraftSML/HelpFilesWriter.cs
+++ b/CustomCraftSML/HelpFilesWriter.cs
@@ -37,7 +37,7 @@
 
                 foreach (TechCategory category in groupCategories.Keys)
                 {
-                    string buildablesFile = $"/{group}_{category}.txt";
+                    string buildablesFile = $"{group}_{category}.txt";
 
                     if (File.Exists(FileLocations.OriginalsFolder + buildablesFile))
                         continue;
@@ -57,10 +57,10 @@
 
         private static void GenerateOriginalBioFuels()
         {
-            const string fileName = "/BioReactor_Values.txt";
-            string Path = FileLocations.OriginalsFolder + fileName;
+            const string fileName = "BioReactor_Values.txt";
+            string path = Path.Combine(FileLocations.OriginalsFolder, fileName);
 
-            if (File.Exists(Path))
+            if (File.Exists(path))
                 return;
 
             Dictionary<TechType, float> allBioFuels = ValidBioFuels.charge;
@@ -79,17 +79,17 @@
 
             printyPrints.Add(bioFuelList.PrettyPrint());
 
-            File.WriteAllLines(Path, printyPrints.ToArray(), Encoding.UTF8);
+            File.WriteAllLines(path, printyPrints.ToArray(), Encoding.UTF8);
 
             QuickLogger.Debug($"{fileName} file not found. File generated.");
         }
 
         private static void GenerateOriginalCraftingPaths()
         {
-            const string fileName = "/CraftingPaths.txt";
-            string Path = FileLocations.OriginalsFolder + fileName;
+            const string fileName = "CraftingPaths.txt";
+            string path = Path.Combine(FileLocations.OriginalsFolder, fileName);
 
-            if (File.Exists(Path))
+            if (File.Exists(path))
                 return;
 
             string[] originalPaths =
@@ -138,17 +138,17 @@
                 "Workbench/ExosuitMenu"
             };
 
-            File.WriteAllLines(Path, originalPaths, Encoding.UTF8);
+            File.WriteAllLines(path, originalPaths, Encoding.UTF8);
 
             QuickLogger.Debug($"{fileName} file not found. File generated.");
         }
 
         private static void GenerateValidFoodModels()
         {
-            const string fileName = "/FoodModels.txt";
-            string Path = FileLocations.OriginalsFolder + fileName;
+            const string fileName = "FoodModels.txt";
+            string path = Path.Combine(FileLocations.OriginalsFolder, fileName);
 
-            if (File.Exists(Path))
+            if (File.Exists(path))
                 return;
 
             var models = (FoodModel[])Enum.GetValues(typeof(FoodModel));
@@ -160,7 +160,7 @@
                 strings[i] = models[i].ToString();
             }
 
-            File.WriteAllLines(Path, strings, Encoding.UTF8);
+            File.WriteAllLines(path, strings, Encoding.UTF8);
 
             QuickLogger.Debug($"{fileName} file not found. File generated.");
         }
@@ -329,7 +329,7 @@
 
             printyPrints.Add(originals.PrettyPrint());
 
-            File.WriteAllLines(FileLocations.OriginalsFolder + fileName, printyPrints.ToArray(), Encoding.UTF8);
+            File.WriteAllLines(Path.Combine(FileLocations.OriginalsFolder, fileName), printyPrints.ToArray(), Encoding.UTF8);
 
             QuickLogger.Debug($"{fileName} file not found. File generated.");
         }

--- a/CustomCraftSML/HelpFilesWriter.cs
+++ b/CustomCraftSML/HelpFilesWriter.cs
@@ -37,7 +37,7 @@
 
                 foreach (TechCategory category in groupCategories.Keys)
                 {
-                    string buildablesFile = $"{group}_{category}.txt";
+                    string buildablesFile = $"/{group}_{category}.txt";
 
                     if (File.Exists(FileLocations.OriginalsFolder + buildablesFile))
                         continue;
@@ -57,7 +57,7 @@
 
         private static void GenerateOriginalBioFuels()
         {
-            const string fileName = "BioReactor_Values.txt";
+            const string fileName = "/BioReactor_Values.txt";
             string Path = FileLocations.OriginalsFolder + fileName;
 
             if (File.Exists(Path))
@@ -86,7 +86,7 @@
 
         private static void GenerateOriginalCraftingPaths()
         {
-            const string fileName = "CraftingPaths.txt";
+            const string fileName = "/CraftingPaths.txt";
             string Path = FileLocations.OriginalsFolder + fileName;
 
             if (File.Exists(Path))
@@ -145,7 +145,7 @@
 
         private static void GenerateValidFoodModels()
         {
-            const string fileName = "FoodModels.txt";
+            const string fileName = "/FoodModels.txt";
             string Path = FileLocations.OriginalsFolder + fileName;
 
             if (File.Exists(Path))

--- a/CustomCraftSML/mod_BelowZero.json
+++ b/CustomCraftSML/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "CustomCraft2SML",
   "DisplayName": "Custom Craft 2",
   "Author": "PrimeSonic & contributors",
-  "Version": "1.9.4",
+  "Version": "1.9.5",
   "Enable": true,
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "BelowZero",

--- a/CustomCraftSML/mod_Subnautica.json
+++ b/CustomCraftSML/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "CustomCraft2SML",
   "DisplayName": "CustomCraft2",
   "Author": "PrimeSonic & contributors",
-  "Version": "1.9.4",
+  "Version": "1.9.5",
   "Enable": true,
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "Subnautica",


### PR DESCRIPTION
Fixes the originals files being created in the mod root dir with the originals folder name stuck to the front instead of being put in the originals folder.