### PR TITLE
fix for cc2 version checker.

### DIFF
--- a/CustomCraftSML/mod_BelowZero.json
+++ b/CustomCraftSML/mod_BelowZero.json
@@ -7,5 +7,5 @@
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "BelowZero",
   "Dependencies": [ "SMLHelper" ],
-  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/PrimeSonic/PrimeSonicSubnauticaMods/master/CustomCraft2SML/mod_BelowZero.json" }
+  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/PrimeSonic/PrimeSonicSubnauticaMods/master/CustomCraftSML/mod_BelowZero.json" }
 }

--- a/CustomCraftSML/mod_Subnautica.json
+++ b/CustomCraftSML/mod_Subnautica.json
@@ -8,5 +8,5 @@
   "Game": "Subnautica",
   "Dependencies": [ "SMLHelper" ],
   "NexusId": { "Subnautica": "114" },
-  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/PrimeSonic/PrimeSonicSubnauticaMods/master/CustomCraft2SML/mod_Subnautica.json" }
+  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/PrimeSonic/PrimeSonicSubnauticaMods/master/CustomCraftSML/mod_Subnautica.json" }
 }


### PR DESCRIPTION
not super important but the version checker links for cc2 were failing due to an incorrectly placed 2