### PR TITLE
AutoZapperLanguageUpdate 

### DIFF
--- a/CyclopsAutoZapper/CyclopsAutoZapper.csproj
+++ b/CyclopsAutoZapper/CyclopsAutoZapper.csproj
@@ -23,7 +23,7 @@
     <GameDir>$(BelowZeroDir)</GameDir>
     <DataFolder>SubnauticaZero_Data</DataFolder>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Subnautica|AnyCPU'">
@@ -33,7 +33,7 @@
     <GameDir>$(SubnauticaDir)</GameDir>
     <DataFolder>Subnautica_Data</DataFolder>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
@@ -70,6 +70,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DisplayTexts.cs" />
     <Compile Include="Items\CyclopsAutoDefenseMk2.cs" />
     <Compile Include="Items\CyclopsParasiteRemover.cs" />
     <Compile Include="Items\CyclopsAutoDefense.cs" />

--- a/CyclopsAutoZapper/DisplayTexts.cs
+++ b/CyclopsAutoZapper/DisplayTexts.cs
@@ -1,0 +1,64 @@
+﻿namespace CyclopsAutoZapper
+{
+    using SMLHelper.V2.Handlers;
+
+    internal class DisplayTexts
+    {
+        private const string PowerLow = "azPowerLow";
+        
+        private const string DefCooling = "azDefCooldown";
+        private const string DefCharged = "azDefCharged";
+        private const string DefMissing = "azDefMis";
+
+        private const string MothConnected = "azMothCon";
+        private const string MothDisconnected = "azMothDisCon";
+
+        private const string ShieldReady = "azShieldRed";
+        private const string ShieldMissing = "azShieldMis";
+
+
+        private DisplayTexts()
+        { }
+
+        public static readonly DisplayTexts Main = new DisplayTexts();
+
+        private string _cyclopsPowerLow;
+
+        private string _defenseCooldown;
+        private string _defenseCharged;
+        private string _defenseMissing;
+
+        private string _mothConnect;
+        private string _mothDisconnect;
+
+        private string _shldConnect;
+        private string _shldDisconnect;
+
+        public string CyclopsPowerLow => _cyclopsPowerLow ??= Language.main.Get(PowerLow);
+
+        public string DefenseCooldown => _defenseCooldown ??= Language.main.Get(DefCooling);
+        public string DefenseCharged => _defenseCharged ??= Language.main.Get(DefCharged);
+        public string DefenseMissing => _defenseMissing ??= Language.main.Get(DefMissing);
+
+        public string SeamothConnected => _mothConnect ??= Language.main.Get(MothConnected);
+        public string SeamothNotConnected => _mothDisconnect ??= Language.main.Get(MothDisconnected);
+
+        public string ShieldConnected => _shldConnect ??= Language.main.Get(ShieldReady);
+        public string ShieldNotConnected => _shldDisconnect ??= Language.main.Get(ShieldMissing);
+
+        public void Patch()
+        {
+            LanguageHandler.Main.SetLanguageLine(PowerLow, "CYCLOPS\nPOWER\nLOW");
+
+            LanguageHandler.Main.SetLanguageLine(DefCooling, "Defense System\n[Cooldown]");
+            LanguageHandler.Main.SetLanguageLine(DefCharged, "Defense System\n[Charged]");
+            LanguageHandler.Main.SetLanguageLine(DefMissing, "Defense System\n[Missing]");
+            
+            LanguageHandler.Main.SetLanguageLine(MothConnected, "Seamoth\n[Connected]");
+            LanguageHandler.Main.SetLanguageLine(MothDisconnected, "Seamoth\n[Not Connected]");
+
+            LanguageHandler.Main.SetLanguageLine(ShieldReady, "Shield\n[Connected]");
+            LanguageHandler.Main.SetLanguageLine(ShieldMissing, "Shield\n[Not Connected]");
+        }
+    }
+}

--- a/CyclopsAutoZapper/Managers/AntiParasiteIconOverlay.cs
+++ b/CyclopsAutoZapper/Managers/AntiParasiteIconOverlay.cs
@@ -15,33 +15,45 @@
 
         public override void UpdateText()
         {
-            base.UpperText.FontSize = 12;
-            base.MiddleText.FontSize = 12;
-            base.LowerText.FontSize = 12;
-
-            if (shieldPulser.HasShieldModule)
+            if (GameModeUtils.RequiresPower() && base.Cyclops.powerRelay.GetPower() < Zapper.EnergyRequiredToZap)
             {
-                base.UpperText.TextString = "Shield\n[Connected]";
-                base.UpperText.TextColor = Color.green;
+                base.MiddleText.FontSize = 20;
+                base.MiddleText.TextString = DisplayTexts.Main.CyclopsPowerLow;
+                base.MiddleText.TextColor = Color.red;
 
-                if (shieldPulser.IsOnCooldown)
-                {
-                    base.LowerText.TextString = "Defense System\n[Cooldown]";
-                    base.LowerText.TextColor = Color.yellow;
-                }
-                else
-                {
-                    base.LowerText.TextString = "Defense System\n[Charged]";
-                    base.LowerText.TextColor = Color.white;
-                }
+                base.UpperText.TextString = string.Empty;
+                base.LowerText.TextString = string.Empty;
             }
             else
             {
-                base.UpperText.TextString = "Shield\n[Not Connected]";
-                base.UpperText.TextColor = Color.red;
+                base.UpperText.FontSize = 12;
+                base.MiddleText.FontSize = 12;
+                base.LowerText.FontSize = 12;
 
-                base.MiddleText.TextString = string.Empty;
-                base.LowerText.TextString = string.Empty;
+                if (shieldPulser.HasShieldModule)
+                {
+                    base.UpperText.TextString = DisplayTexts.Main.ShieldConnected;
+                    base.UpperText.TextColor = Color.green;
+
+                    if (shieldPulser.IsOnCooldown)
+                    {
+                        base.LowerText.TextString = DisplayTexts.Main.DefenseCooldown;
+                        base.LowerText.TextColor = Color.yellow;
+                    }
+                    else
+                    {
+                        base.LowerText.TextString = DisplayTexts.Main.DefenseCharged;
+                        base.LowerText.TextColor = Color.white;
+                    }
+                }
+                else
+                {
+                    base.UpperText.TextString = DisplayTexts.Main.ShieldNotConnected;
+                    base.UpperText.TextColor = Color.red;
+
+                    base.MiddleText.TextString = string.Empty;
+                    base.LowerText.TextString = string.Empty;
+                }
             }
         }
     }

--- a/CyclopsAutoZapper/Managers/AutoDefenseIconOverlay.cs
+++ b/CyclopsAutoZapper/Managers/AutoDefenseIconOverlay.cs
@@ -17,17 +17,12 @@
         {
             if (GameModeUtils.RequiresPower() && base.Cyclops.powerRelay.GetPower() < Zapper.EnergyRequiredToZap)
             {
-                base.UpperText.FontSize = 20;
                 base.MiddleText.FontSize = 20;
-                base.LowerText.FontSize = 20;
-
-                base.UpperText.TextString = "CYCLOPS";
-                base.MiddleText.TextString = "POWER";
-                base.LowerText.TextString = "LOW";
-
-                base.UpperText.TextColor = Color.red;
+                base.MiddleText.TextString = DisplayTexts.Main.CyclopsPowerLow;
                 base.MiddleText.TextColor = Color.red;
-                base.LowerText.TextColor = Color.red;
+
+                base.UpperText.TextString = string.Empty;
+                base.LowerText.TextString = string.Empty;
             }
             else
             {
@@ -36,31 +31,31 @@
 
                 if (zapper.SeamothInBay)
                 {
-                    base.UpperText.TextString = "Seamoth\n[Connected]";
+                    base.UpperText.TextString = DisplayTexts.Main.SeamothConnected;
                     base.UpperText.TextColor = Color.green;
 
                     if (zapper.HasSeamothWithElectricalDefense)
                     {
                         if (zapper.IsOnCooldown)
                         {
-                            base.LowerText.TextString = "Defense System\n[Cooldown]";
+                            base.LowerText.TextString = DisplayTexts.Main.DefenseCooldown;
                             base.LowerText.TextColor = Color.yellow;
                         }
                         else
                         {
-                            base.LowerText.TextString = "Defense System\n[Charged]";
+                            base.LowerText.TextString = DisplayTexts.Main.DefenseCharged;
                             base.LowerText.TextColor = Color.white;
                         }
                     }
                     else
                     {
-                        base.LowerText.TextString = "Defense System\n[Missing]";
+                        base.LowerText.TextString = DisplayTexts.Main.DefenseMissing;
                         base.LowerText.TextColor = Color.red;
                     }
                 }
                 else
                 {
-                    base.UpperText.TextString = "Seamoth\n[Not Connected]";
+                    base.UpperText.TextString = DisplayTexts.Main.SeamothNotConnected;
                     base.UpperText.TextColor = Color.red;
 
                     base.MiddleText.TextString = string.Empty;

--- a/CyclopsAutoZapper/Managers/AutoDefenseMk2IconOverlay.cs
+++ b/CyclopsAutoZapper/Managers/AutoDefenseMk2IconOverlay.cs
@@ -17,17 +17,12 @@
         {
             if (GameModeUtils.RequiresPower() && base.Cyclops.powerRelay.GetPower() < Zapper.EnergyRequiredToZap)
             {
-                base.UpperText.FontSize = 20;
                 base.MiddleText.FontSize = 20;
-                base.LowerText.FontSize = 20;
-
-                base.UpperText.TextString = "CYCLOPS";
-                base.MiddleText.TextString = "POWER";
-                base.LowerText.TextString = "LOW";
-
-                base.UpperText.TextColor = Color.red;
+                base.MiddleText.TextString = DisplayTexts.Main.CyclopsPowerLow;
                 base.MiddleText.TextColor = Color.red;
-                base.LowerText.TextColor = Color.red;
+
+                base.UpperText.TextString = string.Empty;
+                base.LowerText.TextString = string.Empty;
             }
             else
             {
@@ -36,12 +31,12 @@
 
                 if (zapper.IsOnCooldown)
                 {
-                    base.LowerText.TextString = "Defense System\n[Cooldown]";
+                    base.LowerText.TextString = DisplayTexts.Main.DefenseCooldown;
                     base.LowerText.TextColor = Color.yellow;
                 }
                 else
                 {
-                    base.LowerText.TextString = "Defense System\n[Charged]";
+                    base.LowerText.TextString = DisplayTexts.Main.DefenseCharged;
                     base.LowerText.TextColor = Color.white;
                 }
             }

--- a/CyclopsAutoZapper/Properties/AssemblyInfo.cs
+++ b/CyclopsAutoZapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.3.3.0")]
-[assembly: AssemblyFileVersion("4.3.3.0")]
+[assembly: AssemblyVersion("4.3.4.0")]
+[assembly: AssemblyFileVersion("4.3.4.0")]

--- a/CyclopsAutoZapper/QPatch.cs
+++ b/CyclopsAutoZapper/QPatch.cs
@@ -19,6 +19,8 @@
             var defenseSystemMk2 = new CyclopsAutoDefenseMk2(defenseSystem);
             defenseSystemMk2.Patch();
 
+            DisplayTexts.Main.Patch();
+
             var harmony = new Harmony("com.cyclopsautozapper.psmod");
             harmony.PatchAll(Assembly.GetExecutingAssembly());
 

--- a/CyclopsAutoZapper/mod.json
+++ b/CyclopsAutoZapper/mod.json
@@ -2,7 +2,7 @@
   "Id": "CyclopsAutoZapper",
   "DisplayName": "Cyclops Auto-Zappers",
   "Author": "PrimeSonic",
-  "Version": "4.3.3",
+  "Version": "4.3.4",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CyclopsAutoZapper.dll",


### PR DESCRIPTION
- Setting text used in [Icon Overlays](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/wiki/Making-PDA-Icon-Overlays) from SMLHelper's `LanguageHandler`
- Enables support for SMLHelper's [Language Overrides](https://github.com/SubnauticaModding/SMLHelper/wiki/Customizing-mod-text-using-Language-Overrides)
- All language lines for Icon Overlays managed from new `DisplayTexts` class.

Release Candidate: [CyclopsAutoZapper_4-3-4.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/5351110/CyclopsAutoZapper_4-3-4.zip)
