### PR TITLE
CB_OptionalCraftTreeAdd - Custom Batteries v1.2.0 - Optional Crafting Nodes

### DIFF
--- a/CustomBatteries/API/CbItem.cs
+++ b/CustomBatteries/API/CbItem.cs
@@ -61,13 +61,23 @@
         public CBModelData CBModelData { get; set; }
 
         /// <summary>
-        /// Override this optional method if you want to make changes to the your item's <see cref="GameObject"/> as it is being spawned from prefab.<br/>
+        /// Override this optional value if you want to make changes to the your item's <see cref="GameObject"/> as it is being spawned from prefab.<br/>
         /// Use this if you want to add or modify components of your item.
         /// </summary>
         /// <param name="gameObject">The item's gameobject.</param>
         public Action<GameObject> EnhanceGameObject { get; set; }
 
+        /// <summary>
+        /// Override this to <c>false</c> if you do not want CustomBatteries to manage addeding of this item to the Fabricator crafting tree.<br/>
+        /// This property is <c>true</c> by default.
+        /// </summary>
+        public bool AddToFabricator { get; set; } = true;
+
         private TechType _techType = TechType.None;
+
+        /// <summary>
+        /// After <see cref="CbBattery.Patch"/> method is invoked, this property will contain the <see cref="TechType"/> value for this item.
+        /// </summary>
         public TechType TechType
         {
             get

--- a/CustomBatteries/Items/CbCore.cs
+++ b/CustomBatteries/Items/CbCore.cs
@@ -167,8 +167,6 @@
 
         protected abstract string[] StepsToFabricatorTab { get; }
 
-        
-
         public void Patch()
         {
             if (this.IsPatched)
@@ -183,13 +181,16 @@
 
             if (this.Sprite == null)
             {
-                string imageFilePath = IOUtilities.Combine(CbDatabase.ExecutingFolder, this.PluginFolder, this.IconFileName);
+                string imageFilePath = null;
 
-                if (File.Exists(imageFilePath))
+                if (this.PluginFolder != null && this.IconFileName != null)
+                    imageFilePath = IOUtilities.Combine(CbDatabase.ExecutingFolder, this.PluginFolder, this.IconFileName);
+
+                if (imageFilePath != null && File.Exists(imageFilePath))
                     this.Sprite = ImageUtils.LoadSpriteFromFile(imageFilePath);
                 else
                 {
-                    QuickLogger.Warning($"Did not find a matching image file at {imageFilePath}.{Environment.NewLine}Using default sprite instead.");
+                    QuickLogger.Warning($"Did not find a matching image file at {imageFilePath} or in {nameof(CbBattery.CustomIcon)}.{Environment.NewLine}Using default sprite instead.");
                     this.Sprite = SpriteManager.Get(this.PrefabType);
                 }
             }
@@ -199,7 +200,7 @@
             CraftDataHandler.SetTechData(this.TechType, GetBlueprintRecipe());
 
             CraftDataHandler.AddToGroup(TechGroup.Resources, TechCategory.Electronics, this.TechType);
-            
+
             CraftDataHandler.SetEquipmentType(this.TechType, this.ChargerType);
 
             if (this.AddToFabricator)

--- a/CustomBatteries/Items/CbCore.cs
+++ b/CustomBatteries/Items/CbCore.cs
@@ -65,6 +65,8 @@
 
         protected Action<GameObject> EnhanceGameObject { get; set; }
 
+        public bool AddToFabricator { get; set; } = true;
+
         protected CbCore(string classId, bool ionCellSkins)
             : base(classId, $"{classId}PreFab", TechType.None)
         {
@@ -84,6 +86,8 @@
             this.Sprite = packItem.CustomIcon;
 
             this.EnhanceGameObject = packItem.EnhanceGameObject;
+
+            this.AddToFabricator = packItem.AddToFabricator;
         }
 
         public override GameObject GetGameObject()
@@ -198,7 +202,8 @@
             
             CraftDataHandler.SetEquipmentType(this.TechType, this.ChargerType);
 
-            CraftTreeHandler.AddCraftingNode(CraftTree.Type.Fabricator, this.TechType, this.StepsToFabricatorTab);
+            if (this.AddToFabricator)
+                CraftTreeHandler.AddCraftingNode(CraftTree.Type.Fabricator, this.TechType, this.StepsToFabricatorTab);
 
             PrefabHandler.RegisterPrefab(this);
 

--- a/CustomBatteries/Properties/AssemblyInfo.cs
+++ b/CustomBatteries/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/CustomBatteries/Properties/AssemblyInfo.cs
+++ b/CustomBatteries/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.0.2")]
+[assembly: AssemblyFileVersion("1.2.0.2")]

--- a/CustomBatteries/mod_BelowZero.json
+++ b/CustomBatteries/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "CustomBatteries",
   "DisplayName": "Custom Batteries",
   "Author": "PrimeSonic|Seraphim|MrPurple|OSubMarin",
-  "Version": "1.1.1",
+  "Version": "1.2.0",
   "Enable": true,
   "Game": "BelowZero",
   "AssemblyName": "CustomBatteries.dll",

--- a/CustomBatteries/mod_Subnautica.json
+++ b/CustomBatteries/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "CustomBatteries",
   "DisplayName": "Custom Batteries",
   "Author": "PrimeSonic|Seraphim|MrPurple|OSubMarin",
-  "Version": "1.1.1",
+  "Version": "1.2.0",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CustomBatteries.dll",


### PR DESCRIPTION
- New `AddToFabricator` property added
- When manually set to `false`, this will prevent `CbCore` from adding the item to the Fabricator crafting tree via the `CraftTreeHandler`
- Ensures that a default icon will be provided if `CustomIcon` isn't set

[CustomBatteries_1-2-0-v3.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/5577003/CustomBatteries_1-2-0-v3.zip)

