### PR TITLE
CyBioDisplayConfig - Adds a config option to the Cyclops BioReactor

### DIFF
--- a/CyclopsBioReactor/CyBioConfig.cs
+++ b/CyclopsBioReactor/CyBioConfig.cs
@@ -1,0 +1,12 @@
+﻿namespace CyclopsBioReactor
+{
+    using SMLHelper.V2.Json;
+    using SMLHelper.V2.Options.Attributes;
+
+    [Menu("Cyclops BioReactor Options")]
+    public class CyBioConfig : ConfigFile
+    {
+        [Toggle( Label = "Show energy levels on display")]
+        public bool EnergyOnDisplay = true;
+    }
+}

--- a/CyclopsBioReactor/CyclopsBioReactor.csproj
+++ b/CyclopsBioReactor/CyclopsBioReactor.csproj
@@ -94,6 +94,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CyBioConfig.cs" />
     <Compile Include="CyBioreactorTrigger.cs" />
     <Compile Include="Management\CyBioReactorAudioHandler.cs" />
     <Compile Include="Management\CyBioReactorAnimationHandler.cs" />

--- a/CyclopsBioReactor/Management/CyBioReactorDisplayHandler.cs
+++ b/CyclopsBioReactor/Management/CyBioReactorDisplayHandler.cs
@@ -7,6 +7,8 @@
 
     internal class CyBioReactorDisplayHandler
     {
+        internal static CyBioConfig Config;
+
         private readonly CyBioReactorMono _mono;
         private readonly GameObject _gameobject;
         private Text _status;
@@ -50,7 +52,11 @@
 
         public void SetActive(int charge, int capacity, bool draining)
         {
-            if (draining)
+            if (Config?.EnergyOnDisplay == false)
+            {
+                _status.text = Language.main.Get("BaseBioReactorActive");
+            }
+            else if (draining)
             {
                 if (charge == 0)
                 {
@@ -71,7 +77,11 @@
 
         public void SetInActivating(int charge, int capacity, bool draining)
         {
-            if (draining)
+            if (Config?.EnergyOnDisplay == false)
+            {
+                _status.text = Language.main.Get("BaseBioReactorInactive");
+            }
+            else if (draining)
             {
                 _status.text = $"{Language.main.Get("BaseBioReactorInactive")}\n{charge}/{capacity}\n{CyBioReactor.ChargingCyclopsText}";
             }

--- a/CyclopsBioReactor/Properties/AssemblyInfo.cs
+++ b/CyclopsBioReactor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.3.1.0")]
-[assembly: AssemblyFileVersion("4.3.1.0")]
+[assembly: AssemblyVersion("4.4.0.0")]
+[assembly: AssemblyFileVersion("4.4.0.0")]

--- a/CyclopsBioReactor/mod.json
+++ b/CyclopsBioReactor/mod.json
@@ -2,7 +2,7 @@
   "Id": "CyclopsBioReactor",
   "DisplayName": "Cyclops BioReactor",
   "Author": "PrimeSonic|FCStudios",
-  "Version": "4.3.1",
+  "Version": "4.4.0",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CyclopsBioReactor.dll",

--- a/MoreCyclopsUpgrades/API/Charging/CyclopsCharger.cs
+++ b/MoreCyclopsUpgrades/API/Charging/CyclopsCharger.cs
@@ -79,10 +79,10 @@
 
         /// <summary>
         /// Produces power for the Cyclops during the RechargeCyclops update cycle.<para />
-        /// Use this for method rechargable energy drawn from the environment is isn't limited by a material resource.<para />
+        /// Use this for method energy drawn from the environment is isn't limited by a material resource.<para />
         /// This method should return <c>0f</c> if there is no power avaiable from this charging handler.<para/>
         /// You may limit the amount of power produced to only what the cyclops needs or you may return more.<para/>
-        /// DO NOT recharge the Cyclops PowerRelay yourself from this method!!! The MoreCyclopsUpgrades PowerManager will handle that.<para/>
+        /// DO NOT recharge the Cyclops PowerRelay yourself from this method!!! The MoreCyclopsUpgrades ChargerManager will handle that.<para/>
         /// </summary>
         /// <param name="requestedPower">The amount of power being requested by the cyclops; This is the current Power Deficit of the cyclops.</param>
         /// <returns>The amount of power produced by this cyclops charger.</returns>


### PR DESCRIPTION
Allows the energy level numbers to be hidden from the Cyclops BioReactor display.

![20201126143619_1](https://user-images.githubusercontent.com/39146191/100387151-5edd8180-2ff5-11eb-8dd3-a2d430cc4aa1.jpg)
![20201126143615_1](https://user-images.githubusercontent.com/39146191/100387153-5f761800-2ff5-11eb-8821-6cfeaace4157.jpg)


Implemented using SMLHelper's [In-Game Options Menu](https://github.com/SubnauticaModding/SMLHelper/wiki/In-Game-Options-Menu)