### PR TITLE
CB-BatteryEatingFix

### DIFF
--- a/CustomBatteries/Patches/EnergyMixinPatcher.cs
+++ b/CustomBatteries/Patches/EnergyMixinPatcher.cs
@@ -110,6 +110,9 @@
             //Then check for models not already setup.
             foreach (Renderer renderer in __instance.gameObject.GetComponentsInChildren<Renderer>(true))
             {
+                if (renderer.gameObject.GetComponentInParent<Battery>(true) != null)
+                    continue;
+
                 switch (renderer?.material?.mainTexture?.name)
                 {
                     case "battery_01":

--- a/CustomBatteries/Properties/AssemblyInfo.cs
+++ b/CustomBatteries/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.2")]
-[assembly: AssemblyFileVersion("1.2.0.2")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/CustomBatteries/mod_BelowZero.json
+++ b/CustomBatteries/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "CustomBatteries",
   "DisplayName": "Custom Batteries",
   "Author": "PrimeSonic|Seraphim|MrPurple|OSubMarin",
-  "Version": "1.2.0",
+  "Version": "1.2.1",
   "Enable": true,
   "Game": "BelowZero",
   "AssemblyName": "CustomBatteries.dll",

--- a/CustomBatteries/mod_Subnautica.json
+++ b/CustomBatteries/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "CustomBatteries",
   "DisplayName": "Custom Batteries",
   "Author": "PrimeSonic|Seraphim|MrPurple|OSubMarin",
-  "Version": "1.2.0",
+  "Version": "1.2.1",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "CustomBatteries.dll",


### PR DESCRIPTION
Stop using actual batteries to make the custom models which cause them to be eaten when removed from tools.

sorry it took me so long to track down what was causing this....