### PR TITLE
GeneralArmorFraction was not using the bonus from DepthIndex

### DIFF
--- a/UpgradedVehicles/VehicleUpgrader.cs
+++ b/UpgradedVehicles/VehicleUpgrader.cs
@@ -169,7 +169,7 @@
             float reduction = 0.10f * armorModuleCount;
             float bonus = 0.05f * this.DepthIndex;
 
-            float damageReduction = Mathf.Max(1f - reduction, 0.01f);
+            float damageReduction = Mathf.Max(1f - reduction - bonus, 0.01f);
 
             return this.GeneralArmorFraction = damageReduction;
         }


### PR DESCRIPTION
The depth bonus was being calculated but never being used.  This simple code change makes it work like it is described in the comment chart, assuming that is the desired outcome.