### PR TITLE
Preliminary updates for BZ

### DIFF
--- a/CustomBatteries/Items/CbCore.cs
+++ b/CustomBatteries/Items/CbCore.cs
@@ -1,6 +1,7 @@
 ﻿namespace CustomBatteries.Items
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using Common;
@@ -90,11 +91,9 @@
             this.AddToFabricator = packItem.AddToFabricator;
         }
 
-        public override GameObject GetGameObject()
+        public GameObject ModifyPrefab(GameObject prefab)
         {
-            GameObject prefab = CraftData.GetPrefabForTechType(this.PrefabType);
             var obj = GameObject.Instantiate(prefab);
-
             Battery battery = obj.GetComponent<Battery>();
             battery._capacity = this.PowerCapacity;
             battery.name = $"{this.ClassID}BatteryCell";
@@ -141,6 +140,22 @@
             return obj;
         }
 
+#if SUBNAUTICA
+        public override GameObject GetGameObject()
+        {
+            GameObject prefab = CraftData.GetPrefabForTechType(this.PrefabType);
+            return ModifyPrefab(prefab);
+        }
+#endif
+
+        public override IEnumerator GetGameObjectAsync(IOut<GameObject> gameObject)
+        {
+            CoroutineTask<GameObject> task = CraftData.GetPrefabForTechTypeAsync(this.PrefabType);
+            yield return task;
+
+            gameObject.Set(ModifyPrefab(task.GetResult()));
+        }
+
         protected void CreateIngredients(IEnumerable<TechType> parts, List<Ingredient> partsList)
         {
             if (parts == null)
@@ -177,7 +192,7 @@
                 return;
 
             this.TechType = TechTypeHandler.AddTechType(this.ClassID, this.FriendlyName, this.Description, this.UnlocksAtStart);
-
+            
             ProcessBatterySkins();
 
             if (!this.UnlocksAtStart)
@@ -241,7 +256,7 @@
                     Texture2D bumpmap = material?.GetTexture(ShaderPropertyID._BumpMap) as Texture2D;
                     Texture2D spec = material?.GetTexture(ShaderPropertyID._SpecTex) as Texture2D;
                     Texture2D illum = material?.GetTexture(ShaderPropertyID._Illum) as Texture2D;
-                    float illumStrength = material.GetFloat(ShaderPropertyID._GlowStrength);
+                    float illumStrength = material?.GetFloat(ShaderPropertyID._GlowStrength) ?? 0;
 
                     CbDatabase.BatteryModels.Add(this.TechType, this.CustomModelData);
                 }
@@ -254,7 +269,7 @@
                     Texture2D bumpmap = material?.GetTexture(ShaderPropertyID._BumpMap) as Texture2D;
                     Texture2D spec = material?.GetTexture(ShaderPropertyID._SpecTex) as Texture2D;
                     Texture2D illum = material?.GetTexture(ShaderPropertyID._Illum) as Texture2D;
-                    float illumStrength = material.GetFloat(ShaderPropertyID._GlowStrength);
+                    float illumStrength = material?.GetFloat(ShaderPropertyID._GlowStrength) ?? 0;
 
                     CbDatabase.PowerCellModels.Add(this.TechType, this.CustomModelData);
                 }

--- a/CustomBatteries/Properties/AssemblyInfo.cs
+++ b/CustomBatteries/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.1.0")]
-[assembly: AssemblyFileVersion("1.2.1.0")]
+[assembly: AssemblyVersion("1.2.1.1")]
+[assembly: AssemblyFileVersion("1.2.1.1")]


### PR DESCRIPTION
Bugs:
*) Power cell skins: Power cells with UsingIonCellSkins that are inserted into vehicles work as expected, until the game is reloaded - at which point they revert to default power cell skins. Cells without that property do not appear correctly. Both types appear correctly when dropped, the problem exists only on cells installed in vehicles.