### PR TITLE
Mod Archive post Nexus removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,3 @@
 
 For help with mod installation or trouble-shooting strange issues, please refer to the [Subnautica Modding Discord](https://discord.gg/UpWuWwq)
 
-## Mods
-**Mod** | **Description** | **Nexus** 
--|-|- 
-**MoreCyclopsUpgrades** | Provides the framework to expand the Cyclops with lots of new upgrades and more upgrade consoles to fit them all in.<br/>Too many features to list here. | [101](https://www.nexusmods.com/subnautica/mods/101) 
-**Vehicle Upgrades In Cyclops** | Adds all the crafts from the **Moonpool's Vehicle Upgrade Console** to the Cyclops Fabricator. | [83](https://www.nexusmods.com/subnautica/mods/83) 
-**CustomCraft2SML** | A complete replacement for CustomCraft built using SMLHelper for the better compatibility with other mods | [114](https://www.nexusmods.com/subnautica/mods/114) 
-**UpgradedVehicles** | Depth modules add gradually increasingly bonuses to vehicle HP, damage reduction, speed, and engine efficiency.<br/>Improves Hull Armor Module and adds the new vehicle Speed Boost Module | [115](https://www.nexusmods.com/subnautica/mods/115) 
-**DataBoxScannerFix** | Fixes the bug where the Scanner Room would still pick up empty DataBoxes.<br/>Special thanks to [Vlad-00003](https://github.com/Vlad-00003) for making [LargeDepositsFix](https://github.com/Vlad-00003/SubnauticaMods/tree/master/LargeDepositsFix) open source which helped kick start the fix for DataBoxes. | [128](https://www.nexusmods.com/subnautica/mods/128) 
-**MidGame Batteries** | Adds a new Battery and Power Cell that can be crafted shortly after reaching the depths of the Lost River. | [170](https://www.nexusmods.com/subnautica/mods/170) 
-**BetterBioReactor** | All the enhancements of the Cyclops BioReactor brought to the base<br/>Special thanks to [Waisie Milliams Hah](https://github.com/brett-taylor) for helping with the UI additions. | [218](https://www.nexusmods.com/subnautica/mods/218)
-**VehicleModuleFabricator** | Adds a new buildable fabricator for vehicle upgrade modules.<br/>Big thanks to [OSubMarin](https://github.com/K07H/) for getting the new model working.<br/>Now remade inside [CustomCraft2](https://www.nexusmods.com/subnautica/mods/114). | [93](https://www.nexusmods.com/subnautica/mods/93) 
-**IonCubeGenerator** | Makes ion cubes from inside your own base!<br/>Created in collaboration with [ccgould](https://github.com/ccgould) / [FCStudios](https://www.nexusmods.com/subnautica/users/66012691) | [242](https://www.nexusmods.com/subnautica/mods/242) 
-
-### MoreCyclopsUpgrades Powered Mods
-Mods built using the [MoreCyclopsUpgrades](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/wiki) APIs in part or in whole.
-
-**Mod** | **Description** | **Nexus** 
--|-|- 
-**CyclopsAutoZappers** | Use the Seamoth Electrical Defense System as automated protection against hostile predators. | [276](https://www.nexusmods.com/subnautica/mods/276) 
-**CyclopsBioReactor** | Build a miniature, upgradeable bioreactor for your Cyclops.<br/>New bioreactor model created by  [ccgould](https://github.com/ccgould) / [FCStudios](https://www.nexusmods.com/subnautica/users/66012691) | [277](https://www.nexusmods.com/subnautica/mods/277)
-**CyclopsEngineUpgrades** | Adds another 2 tiers of Cyclops Engine Efficiency upgrades. | [275](https://www.nexusmods.com/subnautica/mods/275) 
-**CyclopsNuclearReactor** | The nuclear reactor the Cyclops always deserved!<br/>Created in collaboration with [ccgould](https://github.com/ccgould) / [FCStudios](https://www.nexusmods.com/subnautica/users/66012691) | [241](https://www.nexusmods.com/subnautica/mods/241) 
-**CyclopsNuclearUpgrades** | A tiny nuclear reactor that fits in the upgrade console itself.<br/>Also includes the optional Nuclear Fabricator to build all your nuclear crafts in one place. | [274](https://www.nexusmods.com/subnautica/mods/274) 
-**CyclopsSolarUpgrades** | Provides two tiers of solar charging upgrade modules. | [273](https://www.nexusmods.com/subnautica/mods/273) 
-**CyclopsSpeedUpgrades** | Provides a speed boosting upgrade module for the Cyclops. | [272](https://www.nexusmods.com/subnautica/mods/272) 
-**CyclopsThermalUpgrades** | Improves the original Cyclops Thermal Reactor Module and lets you upgrade it into a better version. | [271](https://www.nexusmods.com/subnautica/mods/271) 
-**CyclopsEnhancedSonar** | (Remake of [CyclopsNearFieldSonar](https://www.nexusmods.com/subnautica/mods/175)) Adds the near field scan effect of the Seaglide to the Cyclops Sonar Upgrade. | [370](https://www.nexusmods.com/subnautica/mods/370) 
-**CyclopsSimpleSolar** | An alternative solar charger for the Cyclops that keeps things simple. No tiers. No stacking. Just simple. | [483](https://www.nexusmods.com/subnautica/mods/483/) 


### PR DESCRIPTION
> This page exists to archive my mods as they were on Nexus by August 5th.
> See also [Release Aug5_2021](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/releases/tag/Aug5_2021)

# Subnautica Mods by PrimeSonic
[AIOFabricator.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927034/AIOFabricator.zip)
`All-in-One Fabricator (SN1)` Makes a new fabricator that is every single fabricator combined together.
Automatically includes modded items and mod created fabricator.

[BetterBioReactor.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927035/BetterBioReactor.zip)
`Better BioReactor (SN1)` Makes the bio reactor in game also show the amount of charge each item has left.
Makes items process in parallel instead of sequentially.

[CyclopsAutoZapper.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927036/CyclopsAutoZapper.zip)
`Cyclops Auto Zapper (SN1)` Two tiers of autozapper, the first tier requires a seamoth in the docking bay that has that shock module installed and the cyclops will automatically shock enemies that attack.
Second tier just takes the cyclops and does not need a seamoth.
Includes an anti parasite module that will pulse the shield (if equipped) at low power to remove leaches.

[CyclopsBioReactor.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927037/CyclopsBioReactor.zip)
`Cyclops BioReactor (SN1)` Makes a small bioreactor you can build inside the cyclops that allows you to use bio energy in the cyclops. Works great with the aquarium overflow mod that is also in `📁mod-download-mirrors`

[CyclopsEngineUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927038/CyclopsEngineUpgrades.zip)
`Cyclops Engine Upgrades (SN1)` makes new tiers of the engine efficiency upgrade each offering increased efficiency.
Higher tiers even reduce energy usage from sonar and shield.

[CyclopsEnhancedSonar.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927039/CyclopsEnhancedSonar.zip)
`Cyclops Enhanced Sonar (SN1)` Adds a topographical map of the area around you similar to the seaglide.
Adding a second module makes the sonar ping faster.

[CyclopsNuclearUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927040/CyclopsNuclearUpgrades.zip)
`Cyclops Nuclear Upgrades (SN1)` makes an upgrade module that acts as a nuclear battery.
Holds 6,000 charge before being depleted, if it is used consistently it must cool down for a while before being able to be used again.

[CyclopsSimpleSolar.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927041/CyclopsSimpleSolar.zip)
`Cyclops Simple Solar (SN1)` makes one simple solar charger that just works as a cyclops version of the seamoth solar charger.

[CyclopsSolarUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927042/CyclopsSolarUpgrades.zip)
`Cyclops Solar Upgrades (SN1)` makes two solar charging upgrades for the cyclops, one is same as seamoth, the other has a built in battery.
Can stack up to six modules to increase charging rate.

[CyclopsSpeedUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927043/CyclopsSpeedUpgrades.zip)
`Cyclops Speed Upgrades (SN1)` Makes upgrade modules that increase the speed of the cyclops at the cost of engine efficiency.
Can stack up to six modules for maximum speed.

[CyclopsThermalUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927044/CyclopsThermalUpgrades.zip)
`Cyclops Thermal Upgrades (SN1)` makes a tier 2 thermal upgrade for the cyclops which includes a built in battery for the upgrade module.
Can stack up to six modules to increase charging rate.

[DataBoxScannerFix.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927045/DataBoxScannerFix.zip)
`DataBox Scanner Fix (SN1)` makes the scanner room not target already collected databoxes.

[IonCubeGenerator.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927046/IonCubeGenerator.zip)
`Ion Cube Generator (SN1)` lets you build a medium sized structure that makes an ion cube every once in a while. about the size of in base bioreactor.
Can be configured to drain base energy faster or slower.

[MoreCyclopsUpgrades.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927047/MoreCyclopsUpgrades.zip)
`More Cyclops Upgrades (SN1)` is primarily if not exclusively an api for other cyclops upgrade mods.
By default, includes a buildable upgrade console for the cyclops for additional upgrade slots (this can be disabled in the config).

[UpgradedVehicles.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927049/UpgradedVehicles.zip)
`Upgraded Vehicles (SN1)` Gives the depth upgrade modules for the seamoth and prawn suit additional effects, 
improving the vehicle's armor, speed, and engine efficiency.

[VehicleUpgradesInCyclops.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927050/VehicleUpgradesInCyclops.zip)
`Vehicle Upgrades In Cyclops (SN1)` Makes the cyclops upgrade fabricator also work as a moonpool vehicle upgrade console. lets you make seamoth and prawn upgrades.
Include includes the vanilla crafts from the moonpool.

# Subnautica Below Zero Mods by PrimeSonic
[UnSlowSeaTruck.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927055/UnSlowSeaTruck.zip)
`UnSlow SeaTruck (BZ)` makes the seatruck unslow by reducing the speed penalty incurred by attaching extra modules on it

[DataBoxScannerFix.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/6927056/DataBoxScannerFix.zip)
`DataBox Scanner Fix (BZ)` makes the scanner room not target already collected databoxes 
