### PR TITLE
Update CustomFabricatorBuildable for non-English translations

### DIFF
--- a/CustomCraftSML/SMLHelperItems/CustomFabricatorBuildable.cs
+++ b/CustomCraftSML/SMLHelperItems/CustomFabricatorBuildable.cs
@@ -63,7 +63,7 @@
             }
 
             crafter.craftTree = FabricatorDetails.TreeTypeID;
-            crafter.handOverText = $"Use {FabricatorDetails.DisplayName}";
+            crafter.handOverText = FabricatorDetails.DisplayName;
 
             if (constructible is null)
                 constructible = prefab.GetComponent<Constructable>();


### PR DESCRIPTION
Removing inline English from Custom Fabricator hover-text.
Will now simply show the full display name for simplicity of translation.