### PR TITLE
CustomCraft2 ~ New Feature: Modified Foods

### DIFF
--- a/CustomCraftSML/CustomCraft2SML.csproj
+++ b/CustomCraftSML/CustomCraft2SML.csproj
@@ -142,6 +142,9 @@
     <Content Include="SampleFiles\AddedRecipes_Samples.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleFiles\ModifiedFoods_Samplefile.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleFiles\CustomSizes_Samples.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/CustomCraftSML/CustomCraft2SML.csproj
+++ b/CustomCraftSML/CustomCraft2SML.csproj
@@ -72,13 +72,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Interfaces\ICustomFood.cs" />
+    <Compile Include="Interfaces\IModifiedFood.cs" />
     <Compile Include="Serialization\Components\EmColor.cs" />
     <Compile Include="Serialization\CraftTreePath.cs" />
     <Compile Include="Serialization\CustomCraft2Config.cs" />
     <Compile Include="Serialization\Entries\CfCustomFood.cs" />
     <Compile Include="Serialization\Entries\CustomFood.cs" />
     <Compile Include="FoodModel.cs" />
+    <Compile Include="Serialization\Entries\ModifiedFood.cs" />
     <Compile Include="Serialization\Lists\CustomFoodList.cs" />
+    <Compile Include="Serialization\Lists\ModifiedFoodList.cs" />
     <Compile Include="SMLHelperItems\CustomFabricatorBuildable.cs" />
     <Compile Include="FileLocations.cs" />
     <Compile Include="SMLHelperItems\CustomFoodPrefab.cs" />

--- a/CustomCraftSML/HelpFilesWriter.cs
+++ b/CustomCraftSML/HelpFilesWriter.cs
@@ -306,7 +306,7 @@
             tutorialLines.Add(HorizontalLine);
             tutorialLines.Add("As of version 1.2, file names no longer matter. All files in the WorkingFiles folder will be read and parsed into the game. So name them however you want.");
             tutorialLines.Add("If you want to be able to easily sahre your custom crafts with others, make sure to chose unique names for your files.");
-            tutorialLines.Add("Remember: For now, each file can only contain one type of entry. The valid entry types are: MovedRecipes, CustomSizes, CustomBioFuels, CustomCraftingTabs, ModifiedRecipes, AddedRecipes, AliasRecipe.");
+            tutorialLines.Add("Remember: For now, each file can only contain one type of entry. The valid entry types are: MovedRecipes, CustomSizes, CustomBioFuels, CustomFoods, CustomFabricators, CustomCraftingTabs, ModifiedRecipes, ModifiedFoods, AddedRecipes, AliasRecipe.");
             tutorialLines.Add(Environment.NewLine);
         }
 

--- a/CustomCraftSML/Interfaces/IModifiedFood.cs
+++ b/CustomCraftSML/Interfaces/IModifiedFood.cs
@@ -1,0 +1,8 @@
+﻿namespace CustomCraft2SML.Interfaces
+{
+    internal interface IModifiedFood : ITechTyped
+    {
+        short FoodValue { get; }
+        short WaterValue { get; }
+    }
+}

--- a/CustomCraftSML/Properties/AssemblyInfo.cs
+++ b/CustomCraftSML/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.0.0")]
-[assembly: AssemblyFileVersion("1.10.0.0")]
+[assembly: AssemblyVersion("1.11.0.0")]
+[assembly: AssemblyFileVersion("1.11.0.0")]
 
 [assembly: InternalsVisibleTo("CustomCraftSMLTests")]

--- a/CustomCraftSML/SampleFiles/CustomFoods_Samplefile.txt
+++ b/CustomCraftSML/SampleFiles/CustomFoods_Samplefile.txt
@@ -22,5 +22,4 @@ CustomFoods:
     FoodValue:20;
     WaterValue:11;
     ForceUnlockAtStart: YES;
-),
-
+);

--- a/CustomCraftSML/SampleFiles/ModifiedFoods_Samplefile.txt
+++ b/CustomCraftSML/SampleFiles/ModifiedFoods_Samplefile.txt
@@ -1,0 +1,10 @@
+ModifiedFoods:
+(
+    ItemID: Peeper;
+    FoodValue:20;
+    WaterValue:-5;
+),
+(
+    ItemID: FilteredWater;
+    WaterValue:50;
+);

--- a/CustomCraftSML/Serialization/Entries/CustomFood.cs
+++ b/CustomCraftSML/Serialization/Entries/CustomFood.cs
@@ -250,7 +250,7 @@
 
             if (this.WaterValue == 0 & this.FoodValue == 0)
             {
-                QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' must have at least one non-zero value for either {FoodKey} or {WaterKey}. Entry will be discarded.");
+                QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' from {this.Origin} must have at least one non-zero value for either {FoodKey} or {WaterKey}. Entry will be discarded.");
                 return false;
             }
 

--- a/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
@@ -1,0 +1,130 @@
+﻿namespace CustomCraft2SML.Serialization.Entries
+{
+    using System;
+    using System.Collections.Generic;
+    using Common;
+    using CustomCraft2SML.Interfaces;
+    using CustomCraft2SML.Interfaces.InternalUse;
+    using CustomCraft2SML.Serialization.Components;
+    using CustomCraft2SML.Serialization.Lists;
+    using EasyMarkup;
+    using SMLHelper.V2.Handlers;
+
+    internal class ModifiedFood : EmTechTyped, IModifiedFood, ICustomCraft
+    {
+        public string[] TutorialText { get; }
+
+        internal static readonly string[] ModifiedFoodTutorial = new[]
+        {
+            $"{ModifiedFoodList.ListKey}: Modify the food and water values of an existing food item.",
+            $"    For use with existing recipies or recipies added by other mods.",
+            $"        {FoodKey}: Defines how much food the user will gain on consumption.",
+            $"            Must be between {MinValue} and {MaxValue}.",
+            $"        {WaterKey}: Defines how much water the user will gain on consumption.",
+            $"            Must be between {MinValue} and {MaxValue}.",
+        };
+
+        internal const short MaxValue = 100;
+        internal const short MinValue = -99;
+
+        public const string TypeName = "ModifiedFood";
+        protected const string FoodKey = "FoodValue";
+        protected const string WaterKey = "WaterValue";
+
+        protected readonly EmProperty<short> foodValue;
+        protected readonly EmProperty<short> waterValue;
+
+        public string ID => this.ItemID;
+
+        public short FoodValue
+        {
+            get => foodValue.Value;
+            set => foodValue.Value = value;
+        }
+        public short WaterValue
+        {
+            get => waterValue.Value;
+            set => waterValue.Value = value;
+        }
+
+        protected static List<EmProperty> ModifiedFoodProperties => new List<EmProperty>
+        {
+            new EmProperty<short>(FoodKey, 0) { Optional = true },
+            new EmProperty<short>(WaterKey, 0) { Optional = true },
+        };
+
+        public ModifiedFood() : this(TypeName, ModifiedFoodProperties)
+        {
+        }
+
+        protected ModifiedFood(string key) : this(key, ModifiedFoodProperties)
+        {
+        }
+
+        protected ModifiedFood(string key, ICollection<EmProperty> definitions) : base(key, definitions)
+        {
+            foodValue = (EmProperty<short>)Properties[FoodKey];
+            waterValue = (EmProperty<short>)Properties[WaterKey];
+        }
+
+        private bool ValidateModifiedFoodValues()
+        {
+            if (this.FoodValue < MinValue || this.FoodValue > MaxValue)
+            {
+                QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' from {this.Origin} has {FoodKey} values out of range. Must be between {MinValue} and {MaxValue}. Entry will be discarded.");
+                return false;
+            }
+
+            if (this.WaterValue < MinValue || this.FoodValue > MaxValue)
+            {
+                QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' from {this.Origin} has {WaterKey} values out of range. Must be between {MinValue} and {MaxValue}. Entry will be discarded.");
+                return false;
+            }
+
+            if (this.WaterValue == 0 & this.FoodValue == 0)
+            {
+                QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' from {this.Origin}  must have at least one non-zero value for either {FoodKey} or {WaterKey}. Entry will be discarded.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool PassesPreValidation(OriginFile originFile)
+        {
+            return base.PassesPreValidation(originFile) & ValidateModifiedFoodValues();
+        }
+
+        public bool PassedSecondValidation
+        {
+            get
+            {
+                if (!CustomFood.IsMappedFoodType(this.TechType))
+                {
+                    QuickLogger.Warning($"ModifiedFood entry '{this.ItemID}' from {this.Origin} is modifying a non-vanilla food item.");
+                }
+                return true;
+            }
+        }
+        public OriginFile Origin { get; set; }
+
+        public bool SendToSMLHelper()
+        {
+            try
+            {
+                EatableHandler.ModifyEatable(this.TechType, this.FoodValue, this.WaterValue);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                QuickLogger.Error($"Exception thrown while handling {this.Key} entry '{this.ItemID}' from {this.Origin}", ex);
+                return false;
+            }
+        }
+
+        internal override EmProperty Copy()
+        {
+            return new ModifiedFood(this.Key, this.CopyDefinitions);
+        }
+    }
+}

--- a/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
@@ -12,7 +12,7 @@
 
     internal class ModifiedFood : EmTechTyped, IModifiedFood, ICustomCraft
     {
-        public string[] TutorialText { get; }
+        public string[] TutorialText => ModifiedFoodTutorial;
 
         internal static readonly string[] ModifiedFoodTutorial = new[]
         {
@@ -47,7 +47,7 @@
             set => waterValue.Value = value;
         }
 
-        protected static List<EmProperty> ModifiedFoodProperties => new List<EmProperty>
+        protected static List<EmProperty> ModifiedFoodProperties => new List<EmProperty>(TechTypedProperties)
         {
             new EmProperty<short>(FoodKey, 0) { Optional = true },
             new EmProperty<short>(WaterKey, 0) { Optional = true },

--- a/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
@@ -17,7 +17,7 @@
         internal static readonly string[] ModifiedFoodTutorial = new[]
         {
             $"{ModifiedFoodList.ListKey}: Modify the food and water values of an existing food item.",
-            $"    For use with existing recipies or recipies added by other mods.",
+            $"    For use with existing food items or ones added by other mods.",
             $"        {FoodKey}: Defines how much food the user will gain on consumption.",
             $"            Must be between {MinValue} and {MaxValue}.",
             $"        {WaterKey}: Defines how much water the user will gain on consumption.",

--- a/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
+++ b/CustomCraftSML/Serialization/Entries/ModifiedFood.cs
@@ -75,7 +75,7 @@
                 return false;
             }
 
-            if (this.WaterValue < MinValue || this.FoodValue > MaxValue)
+            if (this.WaterValue < MinValue || this.WaterValue > MaxValue)
             {
                 QuickLogger.Warning($"{this.Key} entry '{this.ItemID}' from {this.Origin} has {WaterKey} values out of range. Must be between {MinValue} and {MaxValue}. Entry will be discarded.");
                 return false;

--- a/CustomCraftSML/Serialization/Lists/ModifiedFoodList.cs
+++ b/CustomCraftSML/Serialization/Lists/ModifiedFoodList.cs
@@ -1,0 +1,13 @@
+﻿namespace CustomCraft2SML.Serialization.Lists
+{
+    using CustomCraft2SML.Serialization.Entries;
+    using EasyMarkup;
+
+    internal class ModifiedFoodList : EmPropertyCollectionList<ModifiedFood>
+    {
+        internal const string ListKey = "ModifiedFoods";
+        public ModifiedFoodList() : base(ListKey)
+        {
+        }
+    }
+}

--- a/CustomCraftSML/WorkingFileParser.cs
+++ b/CustomCraftSML/WorkingFileParser.cs
@@ -19,6 +19,7 @@
         private static readonly ParsingPackage<AliasRecipe, AliasRecipeList> AliasRecipes = new ParsingPackage<AliasRecipe, AliasRecipeList>(AliasRecipeList.ListKey);
         private static readonly ParsingPackage<CustomFabricator, CustomFabricatorList> CustomFabricators = new ParsingPackage<CustomFabricator, CustomFabricatorList>(CustomFabricatorList.ListKey);
         private static readonly ParsingPackage<ModifiedRecipe, ModifiedRecipeList> ModifiedRecipes = new ParsingPackage<ModifiedRecipe, ModifiedRecipeList>(ModifiedRecipeList.ListKey);
+        private static readonly ParsingPackage<ModifiedFood, ModifiedFoodList> ModifiedFoods = new ParsingPackage<ModifiedFood, ModifiedFoodList>(ModifiedFoodList.ListKey);
         private static readonly ParsingPackage<CustomSize, CustomSizeList> CustomSizes = new ParsingPackage<CustomSize, CustomSizeList>(CustomSizeList.ListKey);
         private static readonly ParsingPackage<CustomBioFuel, CustomBioFuelList> CustomBioFuels = new ParsingPackage<CustomBioFuel, CustomBioFuelList>(CustomBioFuelList.ListKey);
         private static readonly ParsingPackage<CustomFragmentCount, CustomFragmentCountList> CustomFragCounts = new ParsingPackage<CustomFragmentCount, CustomFragmentCountList>(CustomFragmentCountList.ListKey);
@@ -31,6 +32,7 @@
             AddedRecipes,
             AliasRecipes,
             ModifiedRecipes,
+            ModifiedFoods,
             CustomFoods,
             MovedRecipes,
             CustomFragCounts,

--- a/CustomCraftSML/mod_BelowZero.json
+++ b/CustomCraftSML/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "CustomCraft2SML",
   "DisplayName": "Custom Craft 2",
   "Author": "PrimeSonic & contributors",
-  "Version": "1.10.0",
+  "Version": "1.11.0",
   "Enable": true,
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "BelowZero",

--- a/CustomCraftSML/mod_Subnautica.json
+++ b/CustomCraftSML/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "CustomCraft2SML",
   "DisplayName": "CustomCraft2",
   "Author": "PrimeSonic & contributors",
-  "Version": "1.10.0",
+  "Version": "1.11.0",
   "Enable": true,
   "AssemblyName": "CustomCraft2SML.dll",
   "Game": "Subnautica",

--- a/CustomCraftSMLTests/CustomCraftSMLTests.csproj
+++ b/CustomCraftSMLTests/CustomCraftSMLTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="CustomSizeTests.cs" />
     <Compile Include="DequeTests.cs" />
     <Compile Include="EasyMarkupTests.cs" />
+    <Compile Include="ModifiedFoodTests.cs" />
     <Compile Include="ModifiedRecipeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SampleFileTests.cs" />

--- a/CustomCraftSMLTests/ModifiedFoodTests.cs
+++ b/CustomCraftSMLTests/ModifiedFoodTests.cs
@@ -1,0 +1,54 @@
+﻿namespace CustomCraftSMLTests
+{
+    using CustomCraft2SML.Serialization.Entries;
+    using CustomCraft2SML.Serialization.Lists;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ModifiedFoodTests
+    {
+        [Test]
+        public void Deserialize_ModifiedFood_FullDetails()
+        {
+            const string serialized = "ModifiedFood:" + "\r\n" +
+                                      "(" + "\r\n" +
+                                      "    ItemID:filteredwater;" + "\r\n" +                                      "    FoodValue:0;" + "\r\n" +
+                                      "    WaterValue:100;" + "\r\n" +
+                                      ");" + "\r\n";
+
+            var food = new ModifiedFood();
+
+            food.FromString(serialized);
+
+            //Assert.AreEqual(TechType.Aerogel.ToString(), food.ItemID);
+            Assert.AreEqual(0, food.FoodValue);
+            Assert.AreEqual(100, food.WaterValue);
+        }
+
+        [Test]
+        public void Deserialize_ModifiedFoodsList_FullDetails()
+        {
+            const string serialized = "ModifiedFoods:" + "\r\n" +
+                                      "(" + "\r\n" +
+                                      "    ItemID:filteredwater;" + "\r\n" +
+                                      "    FoodValue:0;" + "\r\n" +
+                                      "    WaterValue:100;" + "\r\n" +
+                                      ")," + "\r\n" +
+                                      "(" + "\r\n" +
+                                      "    ItemID:filteredwater;" + "\r\n" +
+                                      "    FoodValue:0;" + "\r\n" +
+                                      "    WaterValue:100;" + "\r\n" +
+                                      ");" + "\r\n";
+
+            var foods = new ModifiedFoodList();
+
+            foods.FromString(serialized);
+
+            Assert.AreEqual(2, foods.Count);
+
+            //Assert.AreEqual(TechType.Aerogel.ToString(), sizes[0].ItemID);
+            Assert.AreEqual(0, foods[0].FoodValue);
+            Assert.AreEqual(100, foods[0].WaterValue);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new entry type `ModifiedFoods` for changing the `Food` and `Water` values of existing Eatable items.
_Currently defaults all modified foods to not decompose._

---

[CustomCraft2SML_1-11-0_SN1.zip](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/files/9592626/CustomCraft2SML_1-11-0_SN1.zip)
built from [275d102](https://github.com/PrimeSonic/PrimeSonicSubnauticaMods/pull/143/commits/275d102ebf4818442e0fbcc7af2e45f9aa44f160)